### PR TITLE
use default:1 for population/popularity when one is not present in th…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "units": "node test/run.js | tap-spec",
-    "test": "npm run unit"
+    "test": "npm run units"
   },
   "repository": {
     "type": "git",

--- a/view/popularity.js
+++ b/view/popularity.js
@@ -21,19 +21,15 @@ module.exports = function( subview ){
         max_boost: vs.var('popularity:max_boost'),
         functions: [],
         score_mode: 'first',
-        boost_mode: 'replace',
-        filter: {
-          'exists': {
-            'field': vs.var('popularity:field')
-          }
-        }
+        boost_mode: 'replace'
       }
     };
 
     view.function_score.functions.push({
       field_value_factor: {
         modifier: vs.var('popularity:modifier'),
-        field: vs.var('popularity:field')
+        field: vs.var('popularity:field'),
+        missing: 1
       },
       weight: vs.var('popularity:weight')
     });

--- a/view/population.js
+++ b/view/population.js
@@ -21,19 +21,15 @@ module.exports = function( subview ){
         max_boost: vs.var('population:max_boost'),
         functions: [],
         score_mode: 'first',
-        boost_mode: 'replace',
-        filter: {
-          'exists': {
-            'field': vs.var('population:field')
-          }
-        }
+        boost_mode: 'replace'
       }
     };
 
     view.function_score.functions.push({
       field_value_factor: {
         modifier: vs.var('population:modifier'),
-        field: vs.var('population:field')
+        field: vs.var('population:field'),
+        missing: 1
       },
       weight: vs.var('population:weight')
     });


### PR DESCRIPTION
use default:1 for population/popularity when one is not present in the data.

documents which did not have a `popularity` or `population` were being penalised too much, this PR gives those records a default value of `1` which reduces the scoring discrepancies
