### PR TITLE
Multi match admin parts

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ module.exports.view = {
   phrase: require('./view/phrase'),
   address: require('./view/address'),
   admin: require('./view/admin'),
+  admin_multi_match: require('./view/admin_multi_match'),
+  multi_match: require('./view/multi_match'),
   boundary_circle: require('./view/boundary_circle'),
   boundary_rect: require('./view/boundary_rect'),
   boundary_country: require('./view/boundary_country'),

--- a/view/admin_multi_match.js
+++ b/view/admin_multi_match.js
@@ -1,0 +1,49 @@
+/**
+  this view is wrapped in a function so it can be re-used
+**/
+
+var multi_match = require('./multi_match');
+
+/*
+ * Match several admin fields against the same query
+ */
+module.exports = function( admin_properties ){
+  return function( vs ){
+
+    // check which of the possible admin_properties are actually set
+    // from the query
+    var valid_admin_properties = admin_properties.filter(function(admin_property) {
+      return admin_property &&
+          vs.isset('input:'+admin_property) &&
+          vs.isset('admin:'+admin_property+':field');
+    });
+
+    if (valid_admin_properties.length === 0) {
+      return null;
+    }
+
+    // from the input parameters, generate a list of fields with boosts to
+    // query against
+    var fields_with_boosts = valid_admin_properties.map(function(admin_property) {
+      var boost = 1;
+      if (vs.isset('admin:' + admin_property + ':boost')) {
+        boost = vs.var('admin:' + admin_property + ':boost');
+      }
+
+      return {
+        field: vs.var('admin:' + admin_property + ':field'),
+        boost: boost
+      };
+    });
+
+    // the actual query text is simply taken from the first valid admin field
+    // this assumes all the values would be the same, which is probably not true
+    // TODO: handle the case where not all admin area input values are the same
+    var queryVar = 'input:' + valid_admin_properties[0];
+
+    // send the parameters to the standard multi_match view
+    var view = multi_match(vs, fields_with_boosts, 'peliasAdmin', queryVar);
+
+    return view;
+  };
+};

--- a/view/multi_match.js
+++ b/view/multi_match.js
@@ -1,0 +1,35 @@
+/***
+ * // simple view for an arbitrary multi_match query
+ *
+ * params:
+ * @fields_with_boosts: objects with a structure like
+ * {
+ *   field: 'fieldName',
+ *   boost: 5 //optional
+ * }
+ * @analyzer: a string for the analyzer name
+ * @query_var: the variable that stores the actual query
+ *
+ */
+module.exports = function( vs, fields_with_boosts, analyzer, query_var ){
+  // base view
+  var view = { multi_match: {} };
+
+  if (!vs.isset(query_var) || !analyzer) {
+    return null;
+  }
+
+  // construct the field string (which contains the boost)
+  // from the more friendly object representation
+  var fields = fields_with_boosts.map(function(data) {
+    var fieldString = data.field;
+    var boost = data.boost || 1;
+    return fieldString +'^' + boost;
+  });
+
+  view.multi_match.fields = fields;
+  view.multi_match.query = vs.var(query_var);
+  view.multi_match.analyzer = analyzer;
+
+  return view;
+};


### PR DESCRIPTION
Add a new generic template for [multi_match](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#query-dsl-multi-match-query) queries, as well as a new admin_multi_match view specifically for querying multiple admin fields.
## How admin_multi_match works

Our address parser currently looks at the `text` field in incoming API requests, and attempts to find admin fields in the text. It often finds things that are probably admin fields, but it doesn't know what level (country, city, state, etc). Previously, we would generate one match query for each possible admin field, which isn't ideal for a couple reasons:

1.) It dilutes the value of any individual match, because Elasticsearch scoring makes keeps track of the number of match statements in a query, and lowers the score contribution of any individual match when there are more of them. A `multi_match` always counts as only one.
2.) It means the same admin value from the query text can match against multiple admin levels at the same time. We don't usually want this.
