### PR TITLE
remove references to deprecated property _cache

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -10,10 +10,8 @@
   "boundary:circle:radius": "50km",
   "boundary:circle:distance_type": "plane",
   "boundary:circle:optimize_bbox": "indexed",
-  "boundary:circle:_cache": true,
 
   "boundary:rect:type": "indexed",
-  "boundary:rect:_cache": true,
 
   "ngram:analyzer": "peliasOneEdgeGram",
   "ngram:field": "name.default",

--- a/layout/FilteredBooleanQuery.js
+++ b/layout/FilteredBooleanQuery.js
@@ -27,12 +27,12 @@ Layout.prototype.render = function( vs ){
   if( this._score.length ){
     this._score.forEach( function( condition ){
       var view = condition[0], operator = condition[1];
-      if( !q.query.filtered.query.bool.hasOwnProperty( operator ) ){
-        q.query.filtered.query.bool[ operator ] = [];
-      }
       var rendered = view( vs );
       if( rendered ){
-        q.query.filtered.query.bool[ operator ].push( rendered );
+        if( !q.query.bool.hasOwnProperty( operator ) ){
+          q.query.bool[ operator ] = [];
+        }
+        q.query.bool[ operator ].push( rendered );
       }
     });
   }
@@ -42,10 +42,10 @@ Layout.prototype.render = function( vs ){
     this._filter.forEach( function( view ){
       var rendered = view( vs );
       if( rendered ){
-        if( !q.query.filtered.hasOwnProperty( 'filter' ) ){
-          q.query.filtered.filter = { bool: { must: [] } };
+        if( !q.query.bool.hasOwnProperty( 'filter' ) ){
+          q.query.bool.filter = [];
         }
-        q.query.filtered.filter.bool.must.push( rendered );
+        q.query.bool.filter.push( rendered );
       }
     });
   }
@@ -66,11 +66,7 @@ Layout.prototype.render = function( vs ){
 Layout.base = function( vs ){
   return {
     query: {
-      filtered: {
-        query: {
-          bool: {}
-        }
-      }
+      bool: {}
     },
     size: vs.var('size'),
     track_scores: vs.var('track_scores'),

--- a/test/layout/FilteredBooleanQuery.js
+++ b/test/layout/FilteredBooleanQuery.js
@@ -15,11 +15,7 @@ module.exports.tests.base_render = function(test, common) {
 
     var expected = {
       query: {
-        filtered: {
-          query: {
-            bool: {}
-          }
-        }
+        bool: {}
       },
       size: { $: 'size value' },
       track_scores: { $: 'track_scores value' },
@@ -69,19 +65,15 @@ module.exports.tests.scores = function(test, common) {
 
     var expected = {
       query: {
-        filtered: {
-          query: {
-            bool: {
-              must: [
-                { 'score field 1': 'score value 1'},
-                { 'score field 3': 'score value 3'}
-              ],
-              should: [
-                { 'score field 2': 'score value 2'},
-                { 'score field 4': 'score value 4'}
-              ]
-            }
-          }
+        bool: {
+          must: [
+            { 'score field 1': 'score value 1'},
+            { 'score field 3': 'score value 3'}
+          ],
+          should: [
+            { 'score field 2': 'score value 2'},
+            { 'score field 4': 'score value 4'}
+          ]
         }
       },
       size: { $: 'size value' },
@@ -111,14 +103,10 @@ module.exports.tests.scores = function(test, common) {
 
     var expected = {
       query: {
-        filtered: {
-          query: {
-            bool: {
-              should: [
-                { 'score field': 'score value'}
-              ]
-            }
-          }
+        bool: {
+          should: [
+            { 'score field': 'score value'}
+          ]
         }
       },
       size: { $: 'size value' },
@@ -148,14 +136,10 @@ module.exports.tests.scores = function(test, common) {
 
     var expected = {
       query: {
-        filtered: {
-          query: {
-            bool: {
-              should: [
-                { 'score field': 'score value'}
-              ]
-            }
-          }
+        bool: {
+          should: [
+            { 'score field': 'score value'}
+          ]
         }
       },
       size: { $: 'size value' },
@@ -195,15 +179,11 @@ module.exports.tests.scores = function(test, common) {
 
     var expected = {
       query: {
-        filtered: {
-          query: {
-            bool: {
-              should: [
-                { 'score field 1': 'score value 1'},
-                { 'score field 2': 'score value 2'}
-              ]
-            }
-          }
+        bool: {
+          should: [
+            { 'score field 1': 'score value 1'},
+            { 'score field 2': 'score value 2'}
+          ]
         }
       },
       size: { $: 'size value' },
@@ -249,18 +229,11 @@ module.exports.tests.filter = function(test, common) {
 
     var expected = {
       query: {
-        filtered: {
-          query: {
-            bool: {}
-          },
-          filter: {
-            bool: {
-              must: [
-                { 'filter field 1': 'filter value 1'},
-                { 'filter field 2': 'filter value 2'}
-              ]
-            }
-          }
+        bool: {
+          filter: [
+            { 'filter field 1': 'filter value 1'},
+            { 'filter field 2': 'filter value 2'}
+          ]
         }
       },
       size: { $: 'size value' },
@@ -305,11 +278,7 @@ module.exports.tests.sort = function(test, common) {
 
     var expected = {
       query: {
-        filtered: {
-          query: {
-            bool: {}
-          }
-        }
+        bool: {}
       },
       size: { $: 'size value' },
       track_scores: { $: 'track_scores value' },

--- a/test/view/boundary_circle.js
+++ b/test/view/boundary_circle.js
@@ -8,7 +8,6 @@ function getBaseVariableStore(toExclude) {
   vs.var('boundary:circle:radius', 'radius value');
   vs.var('boundary:circle:distance_type', 'distance_type value');
   vs.var('boundary:circle:optimize_bbox', 'optimize_bbox value');
-  vs.var('boundary:circle:_cache', 'cache value');
   vs.var('centroid:field', 'field value');
 
   if (toExclude) {
@@ -56,7 +55,6 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
         distance: { $: 'radius value' },
         distance_type: { $: 'distance_type value' },
         optimize_bbox: { $: 'optimize_bbox value' },
-        _cache: { $: 'cache value' },
         'field value': {
           lat: { $: 'lat value' },
           lon: { $: 'lon value' }

--- a/test/view/boundary_rect.js
+++ b/test/view/boundary_rect.js
@@ -8,7 +8,6 @@ function getBaseVariableStore(toExclude) {
   vs.var('boundary:rect:bottom', 'bottom value');
   vs.var('boundary:rect:left', 'left value');
   vs.var('boundary:rect:type', 'type value');
-  vs.var('boundary:rect:_cache', 'cache value');
   vs.var('centroid:field', 'field value');
 
   if (toExclude) {
@@ -54,7 +53,6 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
     var expected = {
       geo_bounding_box: {
         type: { $: 'type value' },
-        _cache: { $: 'cache value' },
         'field value': {
           top: { $: 'top value' },
           right: { $: 'right value' },

--- a/view/boundary_circle.js
+++ b/view/boundary_circle.js
@@ -7,7 +7,6 @@ module.exports = function( vs ){
       !vs.isset('boundary:circle:radius') ||
       !vs.isset('boundary:circle:distance_type') ||
       !vs.isset('boundary:circle:optimize_bbox') ||
-      !vs.isset('boundary:circle:_cache') ||
       !vs.isset('centroid:field') ){
     return null;
   }
@@ -17,8 +16,7 @@ module.exports = function( vs ){
     geo_distance: {
       distance: vs.var('boundary:circle:radius'),
       distance_type: vs.var('boundary:circle:distance_type'),
-      optimize_bbox: vs.var('boundary:circle:optimize_bbox'),
-      _cache: vs.var('boundary:circle:_cache')
+      optimize_bbox: vs.var('boundary:circle:optimize_bbox')
     }
   };
 

--- a/view/boundary_rect.js
+++ b/view/boundary_rect.js
@@ -7,7 +7,6 @@ module.exports = function( vs ){
       !vs.isset('boundary:rect:bottom') ||
       !vs.isset('boundary:rect:left') ||
       !vs.isset('boundary:rect:type') ||
-      !vs.isset('boundary:rect:_cache') ||
       !vs.isset('centroid:field') ){
     return null;
   }
@@ -15,8 +14,7 @@ module.exports = function( vs ){
   // base view
   var view = {
     geo_bounding_box: {
-      type: vs.var('boundary:rect:type'),
-      _cache: vs.var('boundary:rect:_cache')
+      type: vs.var('boundary:rect:type')
     }
   };
 


### PR DESCRIPTION
the `_cache` key has been deprecated in ES2+ as per: https://www.elastic.co/guide/en/elasticsearch/reference/2.1/breaking_20_query_dsl_changes.html#_filter_auto_caching

see also: https://github.com/elastic/elasticsearch/issues/16441

Connects pelias/pelias#325
