### PR TITLE
added unit tests, fixed logic errors

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,3 @@
+node_modules
+coverage
+reports

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,21 @@
+{
+  "node": true,
+  "curly": true,
+  "eqeqeq": true,
+  "freeze": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": false,
+  "newcap": true,
+  "noarg": true,
+  "noempty": true,
+  "nonbsp": true,
+  "nonew": true,
+  "plusplus": false,
+  "quotmark": "single",
+  "undef": true,
+  "unused": false,
+  "maxparams": 4,
+  "maxdepth": 4,
+  "maxlen": 140
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An Elasticsearch query builder for Pelias",
   "main": "index.js",
   "scripts": {
+    "lint": "jshint .",
     "units": "node test/run.js | tap-spec",
     "test": "npm run units"
   },
@@ -18,9 +19,11 @@
   },
   "homepage": "https://github.com/pelias/query#readme",
   "dependencies": {
-    "check-types": "^7.0.0"
+    "check-types": "^7.0.0",
+    "jshint": "^2.9.2"
   },
   "devDependencies": {
+    "jshint": "^2.5.6",
     "tap-spec": "^4.1.0",
     "tape": "^4.2.0"
   }

--- a/test/lib/VariableStore.js
+++ b/test/lib/VariableStore.js
@@ -79,7 +79,7 @@ module.exports.tests.var = function(test, common) {
     var vs = new VariableStore();
 
     var placeholder = vs.var('a');
-    t.equal(vs._vars['a'].get(), '');
+    t.equal(vs._vars.a.get(), '');
     t.equal(placeholder.get(), '');
 
     t.end();
@@ -89,7 +89,7 @@ module.exports.tests.var = function(test, common) {
 
     vs.var('a');
     vs.var('a','b');
-    t.equal(vs._vars['a'].get(), 'b');
+    t.equal(vs._vars.a.get(), 'b');
 
     t.end();
   });
@@ -97,7 +97,7 @@ module.exports.tests.var = function(test, common) {
     var vs = new VariableStore();
 
     vs.var('a','b');
-    t.equal(vs._vars['a'].get(), 'b');
+    t.equal(vs._vars.a.get(), 'b');
 
     t.end();
   });
@@ -144,10 +144,10 @@ module.exports.tests.isset = function(test, common) {
     vs.var('b','test');
     vs.unset('b');
     t.false(vs.isset('b'));
-    
+
     vs.var('c',false);
     t.true(vs.isset('c'));
-    
+
     vs.var('d','test');
     t.true(vs.isset('d'));
 
@@ -236,12 +236,12 @@ module.exports.tests.set = function(test, common) {
 module.exports.tests.export = function(test, common) {
   test('export', function(t) {
     var vs = new VariableStore();
-    
+
     t.deepEqual(vs.export(), {});
 
     vs.var('a',1.1);
     t.deepEqual(vs.export(), {a: 1.1});
-    
+
     t.end();
   });
 };

--- a/test/run.js
+++ b/test/run.js
@@ -4,7 +4,23 @@ var common = {};
 
 var tests = [
   require('./lib/Variable.js'),
-  require('./lib/VariableStore.js')
+  require('./lib/VariableStore.js'),
+  require('./view/address.js'),
+  require('./view/admin.js'),
+  require('./view/admin_multi_match.js'),
+  require('./view/boundary_circle.js'),
+  require('./view/boundary_country.js'),
+  require('./view/boundary_rect.js'),
+  require('./view/focus.js'),
+  require('./view/localregions.js'),
+  require('./view/multi_match.js'),
+  require('./view/ngrams.js'),
+  require('./view/phrase.js'),
+  require('./view/popularity.js'),
+  require('./view/population.js'),
+  require('./view/sort_distance.js'),
+  require('./view/sort_numeric_script.js'),
+  require('./view/sources.js')
 ];
 
 tests.map(function(t) {

--- a/test/view/address.js
+++ b/test/view/address.js
@@ -25,7 +25,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.no_property = function(test, common) {
   test('empty property should return null even if all other fields are present', function(t) {
@@ -88,7 +88,7 @@ module.exports.tests.missing_variable_conditions = function(test, common) {
     });
   });
 
-}
+};
 
 module.exports.tests.no_exceptions_conditions = function(test, common) {
   test('all required values should return formed object', function(t) {
@@ -114,14 +114,14 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           }
         }
       }
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();
 
   });
 
-}
+};
 
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {

--- a/test/view/address.js
+++ b/test/view/address.js
@@ -1,0 +1,133 @@
+var address = require('../../view/address')('asdf');
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('input:asdf', 'input value');
+  vs.var('address:asdf:analyzer', 'analyzer value');
+  vs.var('address:asdf:field', 'field value');
+  vs.var('address:asdf:boost', 'boost value');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    t.equal(typeof address, 'function', 'valid function');
+    t.equal(address.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.no_property = function(test, common) {
+  test('empty property should return null even if all other fields are present', function(t) {
+    var vs = new VariableStore();
+    vs.var('input:', 'input value');
+    vs.var('address::analyzer', 'analyzer value');
+    vs.var('address::field', 'field value');
+    vs.var('address::boost', 'boost value');
+
+    var falseyPropertyAddress = require('../../view/address')('');
+    var actual = address(vs);
+
+    t.equal(actual, null, 'should have returned null');
+    t.end();
+
+  });
+
+  test('0 property should return null even if all other fields are present', function(t) {
+    var vs = new VariableStore();
+    vs.var('input:0', 'input value');
+    vs.var('address:0:analyzer', 'analyzer value');
+    vs.var('address:0:field', 'field value');
+    vs.var('address:0:boost', 'boost value');
+
+    var falseyPropertyAddress = require('../../view/address')(0);
+    var actual = address(vs);
+
+    t.equal(actual, null, 'should have returned null');
+    t.end();
+
+  });
+
+  test('false property should return null even if all other fields are present', function(t) {
+    var vs = new VariableStore();
+    vs.var('input:false', 'input value');
+    vs.var('address:false:analyzer', 'analyzer value');
+    vs.var('address:false:field', 'field value');
+    vs.var('address:false:boost', 'boost value');
+
+    var falseyPropertyAddress = require('../../view/address')(false);
+    var actual = address(vs);
+
+    t.equal(actual, null, 'should have returned null');
+    t.end();
+
+  });
+
+};
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable ' + missing_variable + ' should return null', function(t) {
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(address(vs), null, 'should have returned null for unset ' + missing_variable);
+      t.end();
+
+    });
+  });
+
+}
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all required values should return formed object', function(t) {
+    var vs = new VariableStore();
+    vs.var('input:asdf', 'input value');
+    vs.var('address:asdf:analyzer', 'analyzer value');
+    vs.var('address:asdf:field', 'field value');
+    vs.var('address:asdf:boost', 'boost value');
+
+    var actual = address(vs);
+
+    var expected = {
+      match: {
+        'field value': {
+          analyzer: {
+            $: 'analyzer value'
+          },
+          boost: {
+            $: 'boost value'
+          },
+          query: {
+            $: 'input value'
+          }
+        }
+      }
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+}
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('address ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/admin.js
+++ b/test/view/admin.js
@@ -25,7 +25,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.no_property = function(test, common) {
   ['', 0, false].forEach(function(falseyValue) {
@@ -80,14 +80,14 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           }
         }
       }
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();
 
   });
 
-}
+};
 
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {

--- a/test/view/admin.js
+++ b/test/view/admin.js
@@ -1,0 +1,99 @@
+var admin = require('../../view/admin')('asdf');
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('input:asdf', 'input value');
+  vs.var('admin:asdf:analyzer', 'analyzer value');
+  vs.var('admin:asdf:field', 'field value');
+  vs.var('admin:asdf:boost', 'boost value');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    t.equal(typeof admin, 'function', 'valid function');
+    t.equal(admin.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.no_property = function(test, common) {
+  ['', 0, false].forEach(function(falseyValue) {
+    test('falsey property values should return null even if all other fields are present', function(t) {
+      var admin = require('../../view/admin')(falseyValue);
+
+      var vs = getBaseVariableStore();
+
+      var actual = admin(vs);
+
+      t.equal(actual, null, 'should have returned null');
+      t.end();
+
+    });
+
+  });
+
+};
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable ' + missing_variable + ' should return null', function(t) {
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(admin(vs), null, 'should have returned null for unset ' + missing_variable);
+      t.end();
+
+    });
+  });
+
+};
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all required values should return formed object', function(t) {
+    var vs = getBaseVariableStore();
+
+    var actual = admin(vs);
+
+    var expected = {
+      match: {
+        'field value': {
+          analyzer: {
+            $: 'analyzer value'
+          },
+          boost: {
+            $: 'boost value'
+          },
+          query: {
+            $: 'input value'
+          }
+        }
+      }
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+}
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('admin ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/admin_multi_match.js
+++ b/test/view/admin_multi_match.js
@@ -1,0 +1,140 @@
+var VariableStore = require('../../lib/VariableStore');
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    var admin_multi_match = require('../../view/admin_multi_match');
+
+    t.equal(typeof admin_multi_match, 'function', 'valid function');
+    t.equal(admin_multi_match.length, 1, 'takes 1 args');
+    t.end();
+  });
+
+}
+
+module.exports.tests.invalid_admin_values = function(test, common) {
+  test('empty admin_properties should return null', function(t) {
+    var vs = new VariableStore();
+
+    var admin_multi_match = require('../../view/admin_multi_match')([]);
+
+    var vs = new VariableStore();
+
+    var actual = admin_multi_match(vs);
+
+    t.equal(actual, null, 'should have returned null for unset query_var');
+    t.end();
+
+  });
+
+  test('null in admin_properties should return null', function(t) {
+    var vs = new VariableStore();
+    vs.var('input:property1', 'property1 value');
+    vs.var('admin:property1:field', 'property1_field value');
+    vs.var('admin:property1:boost', 'property1_boost value');
+
+    var admin_multi_match = require('../../view/admin_multi_match')([null]);
+
+    var actual = admin_multi_match(vs);
+
+    t.equal(actual, null);
+    t.end();
+
+  });
+
+  test('admin_properties without input:<property> value not in vs should return null', function(t) {
+    var vs = new VariableStore();
+    vs.var('admin:property1:field', 'field value 1');
+    vs.unset('input:property1');
+
+    var admin_multi_match = require('../../view/admin_multi_match')(['property1']);
+
+    var actual = admin_multi_match(vs);
+
+    t.equal(actual, null);
+    t.end();
+
+  });
+
+  test('admin_properties without admin:<property>:field value not in vs should return null', function(t) {
+    var vs = new VariableStore();
+    vs.var('input:property1', 'value 1');
+    vs.unset('admin:property1:field');
+
+    var admin_multi_match = require('../../view/admin_multi_match')(['property1']);
+
+    var actual = admin_multi_match(vs);
+
+    t.equal(actual, null);
+    t.end();
+
+  });
+
+};
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var vs = new VariableStore();
+    vs.var('input:property1', 'property1 value');
+    vs.var('admin:property1:field', 'property1_field value');
+    vs.var('admin:property1:boost', 'property1_boost value');
+    vs.var('input:property2', 'property2 value');
+    vs.var('admin:property2:field', 'property2_field value');
+    vs.var('admin:property2:boost', 'property2_boost value');
+
+    var admin_multi_match = require('../../view/admin_multi_match')(['property1', 'property2']);
+
+    var actual = admin_multi_match(vs);
+
+    var expected = {
+      'multi_match': {
+        'fields': [
+          'property1_field value^property1_boost value',
+          'property2_field value^property2_boost value'
+        ],
+        'query': { $: 'property1 value' },
+        'analyzer': 'peliasAdmin'
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+  test('boosts should default to 1 when not specified', function(t) {
+    var vs = new VariableStore();
+    vs.var('input:property1', 'property1 value');
+    vs.var('admin:property1:field', 'property1_field value');
+    // there is no boost
+
+    var admin_multi_match = require('../../view/admin_multi_match')(['property1']);
+
+    var actual = admin_multi_match(vs);
+
+    var expected = {
+      'multi_match': {
+        'fields': [
+          'property1_field value^1'
+        ],
+        'query': { $: 'property1 value' },
+        'analyzer': 'peliasAdmin'
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('admin_multi_match ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/admin_multi_match.js
+++ b/test/view/admin_multi_match.js
@@ -11,12 +11,10 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.invalid_admin_values = function(test, common) {
   test('empty admin_properties should return null', function(t) {
-    var vs = new VariableStore();
-
     var admin_multi_match = require('../../view/admin_multi_match')([]);
 
     var vs = new VariableStore();

--- a/test/view/boundary_circle.js
+++ b/test/view/boundary_circle.js
@@ -1,0 +1,81 @@
+var boundary_circle = require('../../view/boundary_circle');
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('boundary:circle:lat', 'lat value');
+  vs.var('boundary:circle:lon', 'lon value');
+  vs.var('boundary:circle:radius', 'radius value');
+  vs.var('boundary:circle:distance_type', 'distance_type value');
+  vs.var('boundary:circle:optimize_bbox', 'optimize_bbox value');
+  vs.var('boundary:circle:_cache', 'cache value');
+  vs.var('centroid:field', 'field value');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    t.equal(typeof boundary_circle, 'function', 'valid function');
+    t.equal(boundary_circle.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable ' + missing_variable + ' should return null', function(t) {
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(boundary_circle(vs), null, 'should have returned null for unset ' + missing_variable);
+      t.end();
+
+    });
+  });
+
+};
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var vs = getBaseVariableStore();
+
+    var actual = boundary_circle(vs);
+
+    var expected = {
+      geo_distance: {
+        distance: { $: 'radius value' },
+        distance_type: { $: 'distance_type value' },
+        optimize_bbox: { $: 'optimize_bbox value' },
+        _cache: { $: 'cache value' },
+        'field value': {
+          lat: { $: 'lat value' },
+          lon: { $: 'lon value' }
+        }
+      }
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+}
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('boundary_circle ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/boundary_circle.js
+++ b/test/view/boundary_circle.js
@@ -28,7 +28,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   var variables = Object.keys(getBaseVariableStore().export());
@@ -62,14 +62,14 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           lon: { $: 'lon value' }
         }
       }
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();
 
   });
 
-}
+};
 
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {

--- a/test/view/boundary_country.js
+++ b/test/view/boundary_country.js
@@ -1,0 +1,77 @@
+var boundary_country = require('../../view/boundary_country');
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('boundary:country', 'boundary_country');
+  vs.var('admin:country_a:analyzer', 'country_a_analyzer');
+  vs.var('admin:country_a:field', 'country_a_field');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    t.equal(typeof boundary_country, 'function', 'valid function');
+    t.equal(boundary_country.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable ' + missing_variable + ' should return null', function(t) {
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(boundary_country(vs), null, 'should have returned null for unset ' + missing_variable);
+      t.end();
+
+    });
+  });
+
+}
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('no boundary:country should return null', function(t) {
+    var vs = getBaseVariableStore();
+
+    var actual = boundary_country(vs);
+
+    var expected = {
+      match: {
+        country_a_field: {
+          analyzer: {
+            $: 'country_a_analyzer'
+          },
+          query: {
+            $: 'boundary_country'
+          }
+        }
+      }
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+}
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('boundary_country ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/boundary_country.js
+++ b/test/view/boundary_country.js
@@ -24,7 +24,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   var variables = Object.keys(getBaseVariableStore().export());
@@ -39,7 +39,7 @@ module.exports.tests.missing_variable_conditions = function(test, common) {
     });
   });
 
-}
+};
 
 module.exports.tests.no_exceptions_conditions = function(test, common) {
   test('no boundary:country should return null', function(t) {
@@ -58,14 +58,14 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           }
         }
       }
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();
 
   });
 
-}
+};
 
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {

--- a/test/view/boundary_rect.js
+++ b/test/view/boundary_rect.js
@@ -1,0 +1,81 @@
+var boundary_rect = require('../../view/boundary_rect');
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('boundary:rect:top', 'top value');
+  vs.var('boundary:rect:right', 'right value');
+  vs.var('boundary:rect:bottom', 'bottom value');
+  vs.var('boundary:rect:left', 'left value');
+  vs.var('boundary:rect:type', 'type value');
+  vs.var('boundary:rect:_cache', 'cache value');
+  vs.var('centroid:field', 'field value');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    t.equal(typeof boundary_rect, 'function', 'valid function');
+    t.equal(boundary_rect.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable ' + missing_variable + ' should return null', function(t) {
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(boundary_rect(vs), null, 'should have returned null for unset ' + missing_variable);
+      t.end();
+
+    });
+  });
+
+};
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var vs = getBaseVariableStore();
+
+    var actual = boundary_rect(vs);
+
+    var expected = {
+      geo_bounding_box: {
+        type: { $: 'type value' },
+        _cache: { $: 'cache value' },
+        'field value': {
+          top: { $: 'top value' },
+          right: { $: 'right value' },
+          bottom: { $: 'bottom value' },
+          left: { $: 'left value' }
+        }
+      }
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+}
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('boundary_rect ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/boundary_rect.js
+++ b/test/view/boundary_rect.js
@@ -28,7 +28,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   var variables = Object.keys(getBaseVariableStore().export());
@@ -62,14 +62,14 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           left: { $: 'left value' }
         }
       }
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();
 
   });
 
-}
+};
 
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {

--- a/test/view/focus.js
+++ b/test/view/focus.js
@@ -1,0 +1,124 @@
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('focus:point:lat', 'lat value');
+  vs.var('focus:point:lon', 'lon value');
+  vs.var('centroid:field', 'field value');
+  vs.var('function_score:score_mode', 'score_mode value');
+  vs.var('function_score:boost_mode', 'boost_mode value');
+  vs.var('focus:weight', 'weight value');
+  vs.var('focus:function', 'function value');
+  vs.var('focus:offset', 'offset value');
+  vs.var('focus:scale', 'scale value');
+  vs.var('focus:decay', 'decay value');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    var focus = require('../../view/focus')(function() {});
+
+    t.equal(typeof focus, 'function', 'valid function');
+    t.equal(focus.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  test('null subview should return null', function(t) {
+    var focus = require('../../view/focus')(null);
+
+    var vs = getBaseVariableStore();
+
+    t.equal(focus(vs), null, 'should have returned null');
+    t.end();
+
+  });
+
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable should return null', function(t) {
+      var focus = require('../../view/focus')(function() {});
+
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(focus(vs), null, 'should have returned null');
+      t.end();
+
+    });
+  });
+
+};
+
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var subview = function(vs) {
+      return {
+        'subview field': 'subview value'
+      };
+    }
+
+    var focus = require('../../view/focus')(subview);
+
+    var vs = getBaseVariableStore();
+
+    var actual = focus(vs);
+
+    var expected = {
+      function_score: {
+        query: {
+          'subview field': 'subview value'
+        },
+        functions: [
+          {
+            weight: { $: 'weight value' },
+            'function value': {
+              'field value': {
+                'origin': {
+                  'lat': { $: 'lat value' },
+                  'lon': { $: 'lon value' }
+                },
+                'offset': { $: 'offset value' },
+                'scale': { $: 'scale value' },
+                'decay': { $: 'decay value' }
+              }
+            }
+          }
+        ],
+        score_mode: {
+          $: 'score_mode value'
+        },
+        boost_mode: {
+          $: 'boost_mode value'
+        }
+      }
+
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('focus ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/focus.js
+++ b/test/view/focus.js
@@ -32,7 +32,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   test('null subview should return null', function(t) {
@@ -68,7 +68,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
       return {
         'subview field': 'subview value'
       };
-    }
+    };
 
     var focus = require('../../view/focus')(subview);
 
@@ -105,7 +105,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
         }
       }
 
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();

--- a/test/view/localregions.js
+++ b/test/view/localregions.js
@@ -30,7 +30,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   var variables = Object.keys(getBaseVariableStore().export());
@@ -79,7 +79,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
         boost_mode: 'replace'
       }
 
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();
@@ -122,12 +122,12 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
         boost_mode: 'replace'
       }
 
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();
 
-  })
+  });
 
 };
 

--- a/test/view/localregions.js
+++ b/test/view/localregions.js
@@ -1,0 +1,141 @@
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('focus:point:lat', 'lat value');
+  vs.var('focus:point:lon', 'lon value');
+  vs.var('centroid:field', 'field value');
+  vs.var('localregions:weight', 'weight value');
+  vs.var('localregions:function', 'function value');
+  vs.var('localregions:offset', 'offset value');
+  vs.var('localregions:scale', 'scale value');
+  vs.var('localregions:decay', 'decay value');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    var localregions = require('../../view/localregions')(function() {});
+
+    t.equal(typeof localregions, 'function', 'valid function');
+    t.equal(localregions.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable should return null', function(t) {
+      var localregions = require('../../view/localregions')(function() {});
+
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(localregions(vs), null, 'should have returned null');
+      t.end();
+
+    });
+  });
+
+};
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var localregions = require('../../view/localregions')();
+
+    var vs = getBaseVariableStore();
+
+    var actual = localregions(vs);
+
+    var expected = {
+      function_score: {
+        functions: [
+          {
+            weight: { $: 'weight value' },
+            'function value': {
+              'field value': {
+                'origin': {
+                  'lat': { $: 'lat value' },
+                  'lon': { $: 'lon value' }
+                },
+                'offset': { $: 'offset value' },
+                'scale': { $: 'scale value' },
+                'decay': { $: 'decay value' }
+              }
+            }
+          }
+        ],
+        score_mode: 'first',
+        boost_mode: 'replace'
+      }
+
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+  test('types should be added as a filter', function(t) {
+    var localregions = require('../../view/localregions')(['type1', 'type2', 'type3']);
+
+    var vs = getBaseVariableStore();
+
+    var actual = localregions(vs);
+
+    var expected = {
+      function_score: {
+        filter: {
+          'or': [
+            { 'type': { 'value': 'type1' }},
+            { 'type': { 'value': 'type2' }},
+            { 'type': { 'value': 'type3' }},
+          ]
+        },
+        functions: [
+          {
+            weight: { $: 'weight value' },
+            'function value': {
+              'field value': {
+                'origin': {
+                  'lat': { $: 'lat value' },
+                  'lon': { $: 'lon value' }
+                },
+                'offset': { $: 'offset value' },
+                'scale': { $: 'scale value' },
+                'decay': { $: 'decay value' }
+              }
+            }
+          }
+        ],
+        score_mode: 'first',
+        boost_mode: 'replace'
+      }
+
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  })
+
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('localregions ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/multi_match.js
+++ b/test/view/multi_match.js
@@ -1,0 +1,67 @@
+var multi_match = require('../../view/multi_match');
+var VariableStore = require('../../lib/VariableStore');
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    t.equal(typeof multi_match, 'function', 'valid function');
+    t.equal(multi_match.length, 4, 'takes 4 args');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  test('missing query_var in VariableStore should return null', function(t) {
+    var vs = new VariableStore();
+
+    var actual = multi_match(vs, [], 'analyzer value', 'query var');
+
+    t.equal(actual, null, 'should have returned null for unset query_var');
+    t.end();
+
+  });
+
+};
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var vs = new VariableStore();
+    vs.var('query var', 'query value');
+
+    var fields_with_boosts = [
+      { field: 'field 1', boost: 'boost value 1'},
+      { field: 'field 2'},
+      { field: 'field 3', boost: 'boost value 3'}
+    ];
+
+    var actual = multi_match(vs, fields_with_boosts, 'analyzer value', 'query var');
+
+    var expected = {
+      multi_match: {
+        fields: [
+          'field 1^boost value 1',
+          'field 2^1',
+          'field 3^boost value 3'
+        ],
+        query: { $: 'query value' },
+        analyzer: 'analyzer value'
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('multi_match ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/multi_match.js
+++ b/test/view/multi_match.js
@@ -10,7 +10,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   test('missing query_var in VariableStore should return null', function(t) {

--- a/test/view/ngrams.js
+++ b/test/view/ngrams.js
@@ -1,0 +1,73 @@
+var ngrams = require('../../view/ngrams');
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('input:name', 'name value');
+  vs.var('ngram:analyzer', 'analyzer value');
+  vs.var('ngram:field', 'field value');
+  vs.var('ngram:boost', 'boost value');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    t.equal(typeof ngrams, 'function', 'valid function');
+    t.equal(ngrams.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable should return null', function(t) {
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(ngrams(vs), null, 'should have returned null');
+      t.end();
+
+    });
+  });
+
+}
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var actual = ngrams(getBaseVariableStore());
+
+    var expected = {
+      match: {
+        'field value': {
+          analyzer: { $: 'analyzer value' },
+          boost: { $: 'boost value' },
+          query: { $: 'name value' }
+        }
+      }
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+}
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('ngrams ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/ngrams.js
+++ b/test/view/ngrams.js
@@ -25,7 +25,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   var variables = Object.keys(getBaseVariableStore().export());
@@ -40,7 +40,7 @@ module.exports.tests.missing_variable_conditions = function(test, common) {
     });
   });
 
-}
+};
 
 module.exports.tests.no_exceptions_conditions = function(test, common) {
   test('all fields available should populate all fields', function(t) {
@@ -54,14 +54,14 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           query: { $: 'name value' }
         }
       }
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();
 
   });
 
-}
+};
 
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {

--- a/test/view/phrase.js
+++ b/test/view/phrase.js
@@ -26,7 +26,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   var variables = Object.keys(getBaseVariableStore().export());
@@ -57,7 +57,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           query: { $: 'name value' }
         }
       }
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();

--- a/test/view/phrase.js
+++ b/test/view/phrase.js
@@ -1,0 +1,76 @@
+var phrase = require('../../view/phrase');
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('input:name', 'name value');
+  vs.var('phrase:analyzer', 'analyzer value');
+  vs.var('phrase:field', 'field value');
+  vs.var('phrase:boost', 'boost value');
+  vs.var('phrase:slop', 'slop value');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    t.equal(typeof phrase, 'function', 'valid function');
+    t.equal(phrase.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable ' + missing_variable + ' should return null', function(t) {
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(phrase(vs), null, 'should have returned null for unset ' + missing_variable);
+      t.end();
+
+    });
+  });
+
+};
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var actual = phrase(getBaseVariableStore());
+
+    var expected = {
+      match: {
+        'field value': {
+          analyzer: { $: 'analyzer value' },
+          type: 'phrase',
+          boost: { $: 'boost value' },
+          slop: { $: 'slop value' },
+          query: { $: 'name value' }
+        }
+      }
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('phrase ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/popularity.js
+++ b/test/view/popularity.js
@@ -25,7 +25,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   test('null subview should return null', function(t) {
@@ -61,7 +61,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
       return {
         'subview field': 'subview value'
       };
-    }
+    };
 
     var popularity = require('../../view/popularity')(subview);
 
@@ -90,7 +90,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
         boost_mode: 'replace'
       }
 
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();

--- a/test/view/popularity.js
+++ b/test/view/popularity.js
@@ -1,0 +1,109 @@
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('popularity:field', 'field value');
+  vs.var('popularity:modifier', 'modifier value');
+  vs.var('popularity:max_boost', 'max_boost value');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    var popularity = require('../../view/popularity')(function() {});
+
+    t.equal(typeof popularity, 'function', 'valid function');
+    t.equal(popularity.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  test('null subview should return null', function(t) {
+    var popularity = require('../../view/popularity')(null);
+
+    var vs = getBaseVariableStore();
+
+    t.equal(popularity(vs), null, 'should have returned null');
+    t.end();
+
+  });
+
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable should return null', function(t) {
+      var popularity = require('../../view/popularity')(function() {});
+
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(popularity(vs), null, 'should have returned null');
+      t.end();
+
+    });
+  });
+
+};
+
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var subview = function(vs) {
+      return {
+        'subview field': 'subview value'
+      };
+    }
+
+    var popularity = require('../../view/popularity')(subview);
+
+    var vs = getBaseVariableStore();
+    vs.var('popularity:weight', 17);
+
+    var actual = popularity(vs);
+
+    var expected = {
+      function_score: {
+        query: {
+          'subview field': 'subview value'
+        },
+        max_boost: { $: 'max_boost value' },
+        functions: [
+          {
+            field_value_factor: {
+              'modifier': { $: 'modifier value' },
+              'field': { $: 'field value' },
+              'missing': 1
+            },
+            weight: { $: 17 }
+          }
+        ],
+        score_mode: 'first',
+        boost_mode: 'replace'
+      }
+
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('popularity ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/population.js
+++ b/test/view/population.js
@@ -25,7 +25,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   test('null subview should return null', function(t) {
@@ -61,7 +61,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
       return {
         'subview field': 'subview value'
       };
-    }
+    };
 
     var population = require('../../view/population')(subview);
 
@@ -90,7 +90,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
         boost_mode: 'replace'
       }
 
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();

--- a/test/view/population.js
+++ b/test/view/population.js
@@ -1,0 +1,109 @@
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('population:field', 'field value');
+  vs.var('population:modifier', 'modifier value');
+  vs.var('population:max_boost', 'max_boost value');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    var population = require('../../view/population')(function() {});
+
+    t.equal(typeof population, 'function', 'valid function');
+    t.equal(population.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  test('null subview should return null', function(t) {
+    var population = require('../../view/population')(null);
+
+    var vs = getBaseVariableStore();
+
+    t.equal(population(vs), null, 'should have returned null');
+    t.end();
+
+  });
+
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable should return null', function(t) {
+      var population = require('../../view/population')(function() {});
+
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(population(vs), null, 'should have returned null');
+      t.end();
+
+    });
+  });
+
+};
+
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var subview = function(vs) {
+      return {
+        'subview field': 'subview value'
+      };
+    }
+
+    var population = require('../../view/population')(subview);
+
+    var vs = getBaseVariableStore();
+    vs.var('population:weight', 17);
+
+    var actual = population(vs);
+
+    var expected = {
+      function_score: {
+        query: {
+          'subview field': 'subview value'
+        },
+        max_boost: { $: 'max_boost value' },
+        functions: [
+          {
+            field_value_factor: {
+              'modifier': { $: 'modifier value' },
+              'field': { $: 'field value' },
+              'missing': 1
+            },
+            weight: { $: 17 }
+          }
+        ],
+        score_mode: 'first',
+        boost_mode: 'replace'
+      }
+
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('population ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/sort_distance.js
+++ b/test/view/sort_distance.js
@@ -26,7 +26,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   var variables = Object.keys(getBaseVariableStore().export());
@@ -41,7 +41,7 @@ module.exports.tests.missing_variable_conditions = function(test, common) {
     });
   });
 
-}
+};
 
 module.exports.tests.no_exceptions_conditions = function(test, common) {
   test('all properties set should return valid object', function(t) {
@@ -58,14 +58,14 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           lon: { $: 'lon value' }
         }
       }
-    }
+    };
 
     t.deepEquals(actual, expected, 'should have returned object');
     t.end();
 
   });
 
-}
+};
 
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {

--- a/test/view/sort_distance.js
+++ b/test/view/sort_distance.js
@@ -1,0 +1,77 @@
+var sort_distance = require('../../view/sort_distance');
+var VariableStore = require('../../lib/VariableStore');
+
+function getBaseVariableStore(toExclude) {
+  var vs = new VariableStore();
+  vs.var('focus:point:lat', 'lat value');
+  vs.var('focus:point:lon', 'lon value');
+  vs.var('sort:distance:order', 'order value');
+  vs.var('sort:distance:distance_type', 'distance_type value');
+  vs.var('centroid:field', 'field value');
+
+  if (toExclude) {
+    vs.unset(toExclude);
+  }
+
+  return vs;
+
+}
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    t.equal(typeof sort_distance, 'function', 'valid function');
+    t.equal(sort_distance.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  var variables = Object.keys(getBaseVariableStore().export());
+
+  variables.forEach(function(missing_variable) {
+    test('missing required variable ' + missing_variable + ' should return null', function(t) {
+      var vs = getBaseVariableStore(missing_variable);
+
+      t.equal(sort_distance(vs), null, 'should have returned null for unset ' + missing_variable);
+      t.end();
+
+    });
+  });
+
+}
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all properties set should return valid object', function(t) {
+    var vs = getBaseVariableStore();
+
+    var actual = sort_distance(vs);
+
+    var expected = {
+      _geo_distance: {
+        order: { $: 'order value' },
+        distance_type: { $: 'distance_type value' },
+        'field value': {
+          lat: { $: 'lat value' },
+          lon: { $: 'lon value' }
+        }
+      }
+    }
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+}
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('sort_distance ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/sort_numeric_script.js
+++ b/test/view/sort_numeric_script.js
@@ -1,0 +1,60 @@
+var VariableStore = require('../../lib/VariableStore');
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    var sort_numeric_script = require('../../view/sort_numeric_script')(function() {});
+
+    t.equal(typeof sort_numeric_script, 'function', 'valid function');
+    t.equal(sort_numeric_script.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  test('null subview should return null', function(t) {
+    var sort_numeric_script = require('../../view/sort_numeric_script')(null);
+
+    var vs = new VariableStore();
+
+    t.equal(sort_numeric_script(vs), null, 'should have returned null');
+    t.end();
+
+  });
+
+};
+
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var sort_numeric_script = require('../../view/sort_numeric_script')('script name value');
+
+    var vs = new VariableStore();
+
+    var actual = sort_numeric_script(vs);
+
+    var expected = {
+      _script: {
+        file: 'script name value',
+        type: 'number',
+        order: 'desc'
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('sort_numeric_script ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/sort_numeric_script.js
+++ b/test/view/sort_numeric_script.js
@@ -11,7 +11,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   test('null subview should return null', function(t) {

--- a/test/view/sources.js
+++ b/test/view/sources.js
@@ -1,0 +1,53 @@
+var sources = require('../../view/sources');
+var VariableStore = require('../../lib/VariableStore');
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: contructor', function(t) {
+    t.equal(typeof sources, 'function', 'valid function');
+    t.equal(sources.length, 1, 'takes 1 arg');
+    t.end();
+  });
+
+}
+
+module.exports.tests.missing_variable_conditions = function(test, common) {
+  test('sources not set in VariableStore should return null', function(t) {
+    var vs = new VariableStore();
+
+    t.equal(sources(vs), null, 'should have returned null');
+    t.end();
+
+  });
+
+};
+
+module.exports.tests.no_exceptions_conditions = function(test, common) {
+  test('all fields available should populate all fields', function(t) {
+    var vs = new VariableStore();
+    vs.var('sources', 'sources value');
+
+    var actual = sources(vs);
+
+    var expected = {
+      terms: {
+        source: { $: 'sources value' }
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('sources ' + name, testFunction);
+  }
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/view/sources.js
+++ b/test/view/sources.js
@@ -10,7 +10,7 @@ module.exports.tests.interface = function(test, common) {
     t.end();
   });
 
-}
+};
 
 module.exports.tests.missing_variable_conditions = function(test, common) {
   test('sources not set in VariableStore should return null', function(t) {

--- a/view/address.js
+++ b/view/address.js
@@ -17,8 +17,8 @@ module.exports = function( property ){
     }
 
     // base view
-    var view = { "match": {} };
-    
+    var view = { 'match': {} };
+
     // match query
     view.match[ vs.var('address:'+property+':field') ] = {
       analyzer: vs.var('address:'+property+':analyzer'),

--- a/view/admin.js
+++ b/view/admin.js
@@ -17,8 +17,8 @@ module.exports = function( property ){
     }
 
     // base view
-    var view = { "match": {} };
-    
+    var view = { 'match': {} };
+
     // match query
     view.match[ vs.var('admin:'+property+':field') ] = {
       analyzer: vs.var('admin:'+property+':analyzer'),

--- a/view/boundary_country.js
+++ b/view/boundary_country.js
@@ -9,7 +9,7 @@ module.exports = function( vs ){
   }
 
   // base view
-  var view = { "match": {} };
+  var view = { 'match': {} };
 
   // match query
   view.match[ vs.var('admin:country_a:field') ] = {

--- a/view/ngrams.js
+++ b/view/ngrams.js
@@ -10,8 +10,8 @@ module.exports = function( vs ){
   }
 
   // base view
-  var view = { "match": {} };
-  
+  var view = { 'match': {} };
+
   // match query
   view.match[ vs.var('ngram:field') ] = {
     analyzer: vs.var('ngram:analyzer'),

--- a/view/phrase.js
+++ b/view/phrase.js
@@ -5,14 +5,14 @@ module.exports = function( vs ){
   if( !vs.isset('input:name') ||
       !vs.isset('phrase:analyzer') ||
       !vs.isset('phrase:field') ||
-      !vs.isset('phrase:boost'),
+      !vs.isset('phrase:boost') || 
       !vs.isset('phrase:slop') ){
     return null;
   }
 
   // base view
   var view = { "match": {} };
-  
+
   // match query
   view.match[ vs.var('phrase:field') ] = {
     analyzer: vs.var('phrase:analyzer'),

--- a/view/phrase.js
+++ b/view/phrase.js
@@ -5,13 +5,13 @@ module.exports = function( vs ){
   if( !vs.isset('input:name') ||
       !vs.isset('phrase:analyzer') ||
       !vs.isset('phrase:field') ||
-      !vs.isset('phrase:boost') || 
+      !vs.isset('phrase:boost') ||
       !vs.isset('phrase:slop') ){
     return null;
   }
 
   // base view
-  var view = { "match": {} };
+  var view = { 'match': {} };
 
   // match query
   view.match[ vs.var('phrase:field') ] = {

--- a/view/popularity.js
+++ b/view/popularity.js
@@ -9,7 +9,7 @@ module.exports = function( subview ){
 
     // validate required params
     if( !vs.isset('popularity:field') ||
-        !vs.isset('popularity:modifier'),
+        !vs.isset('popularity:modifier') ||
         !vs.isset('popularity:max_boost') ){
       return null;
     }

--- a/view/population.js
+++ b/view/population.js
@@ -9,7 +9,7 @@ module.exports = function( subview ){
 
     // validate required params
     if( !vs.isset('population:field') ||
-        !vs.isset('population:modifier'),
+        !vs.isset('population:modifier') || 
         !vs.isset('population:max_boost') ){
       return null;
     }

--- a/view/sort_numeric_script.js
+++ b/view/sort_numeric_script.js
@@ -14,7 +14,7 @@ module.exports = function( script_name ){
 
     // groovy script
     var view = {
-      "_script": {
+      '_script': {
         'file': script_name,
         'type': 'number',
         'order': 'desc'

--- a/view/sources.js
+++ b/view/sources.js
@@ -8,4 +8,4 @@ module.exports = function( vs ){
       source: vs.var('sources')
     }
   };
-}
+};


### PR DESCRIPTION
Fixed #18 

Added unit tests for all views, including negative tests.

Additionally, 3 views had logic errors that were causing unintended behavior in parameter validation.  For example:

```
if( !vs.isset('popularity:field') ||
    !vs.isset('popularity:modifier'), // , used when || was intended
    !vs.isset('popularity:max_boost') ){
  return null;
}
```

The effect of the above behavior is that the conditional would only succeed when `!vs.isset('popularity:max_boost')` evaluated to true.  When a list of statements is separated by a `,`, all statements are executed but only the last is used for the outer expression evaluation.  See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator
