### PR TITLE
added `nocomma` to stop the bad

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,6 +8,7 @@
   "latedef": false,
   "newcap": true,
   "noarg": true,
+  "nocomma": true,
   "noempty": true,
   "nonbsp": true,
   "nonew": true,


### PR DESCRIPTION
This will stop inadvertent `if (true, false) { ... }` statements.  This appears to disable all comma operators except in assigning variables.  That is, `var a = 1, b = 2` is still legit.  
