### PR TITLE
Remove Node 0.10 from Travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 notifications:
   email: false
 node_js:
-  - 0.10
   - 0.12
   - 4
   - 5


### PR DESCRIPTION
It's been mostly depricated in our importers, so we can start removing
it elsewhere.
