### PR TITLE
added support for counties

### DIFF
--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -115,6 +115,12 @@ function addQuery(vs) {
       ['parent.locality', 'parent.locality_a', 'parent.localadmin', 'parent.localadmin_a']));
   }
 
+  // add county if specified
+  if (vs.isset('input:county')) {
+    o.bool.must.push(addSecondary(vs.var('input:county').toString(),
+      ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']));
+  }
+
   // add region if specified
   if (vs.isset('input:region')) {
     o.bool.must.push(addSecondary(vs.var('input:region').toString(), ['parent.region', 'parent.region_a']));
@@ -168,6 +174,12 @@ function addHouseNumberAndStreet(vs) {
       ['parent.locality', 'parent.locality_a', 'parent.localadmin', 'parent.localadmin_a']));
   }
 
+  // add county if specified
+  if (vs.isset('input:county')) {
+    o.bool.must.push(addSecondary(vs.var('input:county').toString(),
+      ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']));
+  }
+
   // add region if specified
   if (vs.isset('input:region')) {
     o.bool.must.push(addSecondary(vs.var('input:region').toString(), ['parent.region', 'parent.region_a']));
@@ -196,6 +208,12 @@ function addNeighbourhood(vs) {
       ['parent.locality', 'parent.locality_a', 'parent.localadmin', 'parent.localadmin_a']));
   }
 
+  // add county if specified
+  if (vs.isset('input:county')) {
+    o.bool.must.push(addSecondary(vs.var('input:county').toString(),
+      ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']));
+  }
+
   // add region if specified
   if (vs.isset('input:region')) {
     o.bool.must.push(addSecondary(vs.var('input:region').toString(), ['parent.region', 'parent.region_a']));
@@ -220,6 +238,12 @@ function addBorough(vs) {
       ['parent.locality', 'parent.locality_a', 'parent.localadmin', 'parent.localadmin_a']));
   }
 
+  // add county if specified
+  if (vs.isset('input:county')) {
+    o.bool.must.push(addSecondary(vs.var('input:county').toString(),
+      ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']));
+  }
+
   // add region if specified
   if (vs.isset('input:region')) {
     o.bool.must.push(addSecondary(vs.var('input:region').toString(), ['parent.region', 'parent.region_a']));
@@ -237,6 +261,30 @@ function addBorough(vs) {
 function addLocality(vs) {
   var o = addPrimary(vs.var('input:locality').toString(),
             'locality', ['parent.locality', 'parent.locality_a'], false);
+
+  // add county if specified
+  if (vs.isset('input:county')) {
+    o.bool.must.push(addSecondary(vs.var('input:county').toString(),
+      ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']));
+  }
+
+  // add region if specified
+  if (vs.isset('input:region')) {
+    o.bool.must.push(addSecondary(vs.var('input:region').toString(), ['parent.region', 'parent.region_a']));
+  }
+
+  // add country if specified
+  if (vs.isset('input:country')) {
+    o.bool.must.push(addSecondary(vs.var('input:country').toString(), ['parent.country', 'parent.country_a']));
+  }
+
+  return o;
+
+}
+
+function addCounty(vs) {
+  var o = addPrimary(vs.var('input:county').toString(),
+            'county', ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a'], false);
 
   // add region if specified
   if (vs.isset('input:region')) {
@@ -290,6 +338,9 @@ Layout.prototype.render = function( vs ){
   }
   if (vs.isset('input:locality')) {
     q.query.bool.should.push(addLocality(vs));
+  }
+  if (vs.isset('input:county')) {
+    q.query.bool.should.push(addCounty(vs));
   }
   if (vs.isset('input:region')) {
     q.query.bool.should.push(addRegion(vs));

--- a/test/layout/FallbackQuery.js
+++ b/test/layout/FallbackQuery.js
@@ -86,6 +86,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('input:neighbourhood', 'neighbourhood value');
     vs.var('input:borough', 'borough value');
     vs.var('input:locality', 'locality value');
+    vs.var('input:county', 'county value');
     vs.var('input:region', 'region value');
     vs.var('input:country', 'country value');
 
@@ -125,6 +126,13 @@ module.exports.tests.base_render = function(test, common) {
                       query: 'locality value',
                       type: 'phrase',
                       fields: ['parent.locality', 'parent.locality_a', 'parent.localadmin', 'parent.localadmin_a']
+                    }
+                  },
+                  {
+                    multi_match: {
+                      query: 'county value',
+                      type: 'phrase',
+                      fields: ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']
                     }
                   },
                   {
@@ -186,6 +194,13 @@ module.exports.tests.base_render = function(test, common) {
                   },
                   {
                     multi_match: {
+                      query: 'county value',
+                      type: 'phrase',
+                      fields: ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']
+                    }
+                  },
+                  {
+                    multi_match: {
                       query: 'region value',
                       type: 'phrase',
                       fields: ['parent.region', 'parent.region_a']
@@ -233,6 +248,13 @@ module.exports.tests.base_render = function(test, common) {
                   },
                   {
                     multi_match: {
+                      query: 'county value',
+                      type: 'phrase',
+                      fields: ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']
+                    }
+                  },
+                  {
+                    multi_match: {
                       query: 'region value',
                       type: 'phrase',
                       fields: ['parent.region', 'parent.region_a']
@@ -273,6 +295,13 @@ module.exports.tests.base_render = function(test, common) {
                   },
                   {
                     multi_match: {
+                      query: 'county value',
+                      type: 'phrase',
+                      fields: ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']
+                    }
+                  },
+                  {
+                    multi_match: {
                       query: 'region value',
                       type: 'phrase',
                       fields: ['parent.region', 'parent.region_a']
@@ -306,6 +335,13 @@ module.exports.tests.base_render = function(test, common) {
                   },
                   {
                     multi_match: {
+                      query: 'county value',
+                      type: 'phrase',
+                      fields: ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']
+                    }
+                  },
+                  {
+                    multi_match: {
                       query: 'region value',
                       type: 'phrase',
                       fields: ['parent.region', 'parent.region_a']
@@ -322,6 +358,39 @@ module.exports.tests.base_render = function(test, common) {
                 filter: {
                   term: {
                     layer: 'locality'
+                  }
+                }
+              }
+            },
+            {
+              bool: {
+                _name: 'fallback.county',
+                must: [
+                  {
+                    multi_match: {
+                      query: 'county value',
+                      type: 'phrase',
+                      fields: ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']
+                    }
+                  },
+                  {
+                    multi_match: {
+                      query: 'region value',
+                      type: 'phrase',
+                      fields: ['parent.region', 'parent.region_a']
+                    }
+                  },
+                  {
+                    multi_match: {
+                      query: 'country value',
+                      type: 'phrase',
+                      fields: ['parent.country', 'parent.country_a']
+                    }
+                  }
+                ],
+                filter: {
+                  term: {
+                    layer: 'county'
                   }
                 }
               }
@@ -394,6 +463,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('input:neighbourhood', 'neighbourhood value');
     vs.var('input:borough', 'borough value');
     vs.var('input:locality', 'locality value');
+    vs.var('input:county', 'county value');
     vs.var('input:region', 'region value');
     vs.var('input:country', 'country value');
 
@@ -436,6 +506,13 @@ module.exports.tests.base_render = function(test, common) {
                       query: 'locality value',
                       type: 'phrase',
                       fields: ['parent.locality', 'parent.locality_a', 'parent.localadmin', 'parent.localadmin_a']
+                    }
+                  },
+                  {
+                    multi_match: {
+                      query: 'county value',
+                      type: 'phrase',
+                      fields: ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']
                     }
                   },
                   {
@@ -487,6 +564,13 @@ module.exports.tests.base_render = function(test, common) {
                   },
                   {
                     multi_match: {
+                      query: 'county value',
+                      type: 'phrase',
+                      fields: ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']
+                    }
+                  },
+                  {
+                    multi_match: {
                       query: 'region value',
                       type: 'phrase',
                       fields: ['parent.region', 'parent.region_a']
@@ -527,6 +611,13 @@ module.exports.tests.base_render = function(test, common) {
                   },
                   {
                     multi_match: {
+                      query: 'county value',
+                      type: 'phrase',
+                      fields: ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']
+                    }
+                  },
+                  {
+                    multi_match: {
                       query: 'region value',
                       type: 'phrase',
                       fields: ['parent.region', 'parent.region_a']
@@ -560,6 +651,13 @@ module.exports.tests.base_render = function(test, common) {
                   },
                   {
                     multi_match: {
+                      query: 'county value',
+                      type: 'phrase',
+                      fields: ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']
+                    }
+                  },
+                  {
+                    multi_match: {
                       query: 'region value',
                       type: 'phrase',
                       fields: ['parent.region', 'parent.region_a']
@@ -576,6 +674,39 @@ module.exports.tests.base_render = function(test, common) {
                 filter: {
                   term: {
                     layer: 'locality'
+                  }
+                }
+              }
+            },
+            {
+              bool: {
+                _name: 'fallback.county',
+                must: [
+                  {
+                    multi_match: {
+                      query: 'county value',
+                      type: 'phrase',
+                      fields: ['parent.county', 'parent.county_a', 'parent.macrocounty', 'parent.macrocounty_a']
+                    }
+                  },
+                  {
+                    multi_match: {
+                      query: 'region value',
+                      type: 'phrase',
+                      fields: ['parent.region', 'parent.region_a']
+                    }
+                  },
+                  {
+                    multi_match: {
+                      query: 'country value',
+                      type: 'phrase',
+                      fields: ['parent.country', 'parent.country_a']
+                    }
+                  }
+                ],
+                filter: {
+                  term: {
+                    layer: 'county'
                   }
                 }
               }


### PR DESCRIPTION
This PR allows FallbackQuery to query at the `county` layer as primary and secondary.  

Fixes #37 
