### PR TITLE
Add dependency support

### DIFF
--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -121,7 +121,8 @@ function addQuery(vs) {
   }
 
   if (vs.isset('input:country')) {
-    o.bool.must.push(addSecondary(vs.var('input:country').toString(), ['parent.country', 'parent.country_a']));
+    o.bool.must.push(addSecondary(vs.var('input:country').toString(),
+      ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']));
   }
 
   return o;
@@ -174,7 +175,8 @@ function addHouseNumberAndStreet(vs) {
   }
 
   if (vs.isset('input:country')) {
-    o.bool.must.push(addSecondary(vs.var('input:country').toString(), ['parent.country', 'parent.country_a']));
+    o.bool.must.push(addSecondary(vs.var('input:country').toString(),
+      ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']));
   }
 
   return o;
@@ -203,7 +205,8 @@ function addNeighbourhood(vs) {
 
   // add country if specified
   if (vs.isset('input:country')) {
-    o.bool.must.push(addSecondary(vs.var('input:country').toString(), ['parent.country', 'parent.country_a']));
+    o.bool.must.push(addSecondary(vs.var('input:country').toString(),
+      ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']));
   }
 
   return o;
@@ -227,7 +230,8 @@ function addBorough(vs) {
 
   // add country if specified
   if (vs.isset('input:country')) {
-    o.bool.must.push(addSecondary(vs.var('input:country').toString(), ['parent.country', 'parent.country_a']));
+    o.bool.must.push(addSecondary(vs.var('input:country').toString(),
+      ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']));
   }
 
   return o;
@@ -245,7 +249,8 @@ function addLocality(vs) {
 
   // add country if specified
   if (vs.isset('input:country')) {
-    o.bool.must.push(addSecondary(vs.var('input:country').toString(), ['parent.country', 'parent.country_a']));
+    o.bool.must.push(addSecondary(vs.var('input:country').toString(),
+      ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']));
   }
 
   return o;
@@ -258,7 +263,8 @@ function addRegion(vs) {
 
   // add country if specified
   if (vs.isset('input:country')) {
-    o.bool.must.push(addSecondary(vs.var('input:country').toString(), ['parent.country', 'parent.country_a']));
+    o.bool.must.push(addSecondary(vs.var('input:country').toString(),
+      ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']));
   }
 
   return o;
@@ -267,7 +273,7 @@ function addRegion(vs) {
 
 function addCountry(vs) {
   var o = addPrimary(vs.var('input:country').toString(),
-            'country', ['parent.country', 'parent.country_a'], true);
+            'country', ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a'], true);
 
   return o;
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "homepage": "https://github.com/pelias/query#readme",
   "dependencies": {
-    "check-types": "^7.0.0"
+    "check-types": "^7.0.0",
+    "lodash": "^4.14.1"
   },
   "devDependencies": {
     "deep-diff": "^0.3.4",

--- a/test/layout/FallbackQuery.js
+++ b/test/layout/FallbackQuery.js
@@ -138,7 +138,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -195,7 +195,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -242,7 +242,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -282,7 +282,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -315,7 +315,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -341,7 +341,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -360,7 +360,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -449,7 +449,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -496,7 +496,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -536,7 +536,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -569,7 +569,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -595,7 +595,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],
@@ -614,7 +614,7 @@ module.exports.tests.base_render = function(test, common) {
                     multi_match: {
                       query: 'country value',
                       type: 'phrase',
-                      fields: ['parent.country', 'parent.country_a']
+                      fields: ['parent.country', 'parent.country_a', 'parent.dependency', 'parent.dependency_a']
                     }
                   }
                 ],

--- a/test/layout/GeodisambiguationQuery.js
+++ b/test/layout/GeodisambiguationQuery.js
@@ -1,12 +1,12 @@
-var CoarseBooleanQuery = require('../../layout/GeodisambiguationQuery');
+var GeodisambiguationQuery = require('../../layout/GeodisambiguationQuery');
 var VariableStore = require('../../lib/VariableStore');
 var diff = require('deep-diff').diff;
 
 module.exports.tests = {};
 
 module.exports.tests.base_render = function(test, common) {
-  test('VariableStore with neighbourhood-only should only include neighbourhood parts and no fallbacks', function(t) {
-    var query = new CoarseBooleanQuery();
+  test('neighbourhood as most granular should only query neighbourhood value across all coarse layers', function(t) {
+    var query = new GeodisambiguationQuery();
 
     var vs = new VariableStore();
     vs.var('size', 'size value');
@@ -20,7 +20,7 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.bool.should.length, 9);
+    t.equals(actual.query.bool.should.length, 10);
     t.deepEquals(actual.query.bool.should[0], individualLayer('neighbourhood',
         'coarse neighbourhood value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
     t.deepEquals(actual.query.bool.should[1], individualLayer('borough',
@@ -37,7 +37,9 @@ module.exports.tests.base_render = function(test, common) {
         'coarse neighbourhood value', ['parent.region', 'parent.region_a']));
     t.deepEquals(actual.query.bool.should[7], individualLayer('macroregion',
         'coarse neighbourhood value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.bool.should[8], individualLayer('country',
+    t.deepEquals(actual.query.bool.should[8], individualLayer('dependency',
+        'coarse neighbourhood value', ['parent.dependency', 'parent.dependency_a']));
+    t.deepEquals(actual.query.bool.should[9], individualLayer('country',
         'coarse neighbourhood value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');
@@ -47,8 +49,8 @@ module.exports.tests.base_render = function(test, common) {
 
   });
 
-  test('VariableStore with borough-only should only include borough parts and no fallbacks', function(t) {
-    var query = new CoarseBooleanQuery();
+  test('borough as most granular should only query borough value across all coarse layers', function(t) {
+    var query = new GeodisambiguationQuery();
 
     var vs = new VariableStore();
     vs.var('size', 'size value');
@@ -61,7 +63,7 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.bool.should.length, 9);
+    t.equals(actual.query.bool.should.length, 10);
     t.deepEquals(actual.query.bool.should[0], individualLayer('neighbourhood',
         'coarse borough value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
     t.deepEquals(actual.query.bool.should[1], individualLayer('borough',
@@ -78,7 +80,9 @@ module.exports.tests.base_render = function(test, common) {
         'coarse borough value', ['parent.region', 'parent.region_a']));
     t.deepEquals(actual.query.bool.should[7], individualLayer('macroregion',
         'coarse borough value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.bool.should[8], individualLayer('country',
+    t.deepEquals(actual.query.bool.should[8], individualLayer('dependency',
+        'coarse borough value', ['parent.dependency', 'parent.dependency_a']));
+    t.deepEquals(actual.query.bool.should[9], individualLayer('country',
         'coarse borough value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');
@@ -88,8 +92,8 @@ module.exports.tests.base_render = function(test, common) {
 
   });
 
-  test('VariableStore with locality-only should only include city parts and no fallbacks', function(t) {
-    var query = new CoarseBooleanQuery();
+  test('city as most granular should only query city value across all coarse layers', function(t) {
+    var query = new GeodisambiguationQuery();
 
     var vs = new VariableStore();
     vs.var('size', 'size value');
@@ -101,7 +105,7 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.bool.should.length, 9);
+    t.equals(actual.query.bool.should.length, 10);
     t.deepEquals(actual.query.bool.should[0], individualLayer('neighbourhood',
         'coarse city value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
     t.deepEquals(actual.query.bool.should[1], individualLayer('borough',
@@ -118,7 +122,9 @@ module.exports.tests.base_render = function(test, common) {
         'coarse city value', ['parent.region', 'parent.region_a']));
     t.deepEquals(actual.query.bool.should[7], individualLayer('macroregion',
         'coarse city value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.bool.should[8], individualLayer('country',
+    t.deepEquals(actual.query.bool.should[8], individualLayer('dependency',
+        'coarse city value', ['parent.dependency', 'parent.dependency_a']));
+    t.deepEquals(actual.query.bool.should[9], individualLayer('country',
         'coarse city value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');
@@ -128,8 +134,8 @@ module.exports.tests.base_render = function(test, common) {
 
   });
 
-  test('VariableStore with county-only should only include neighbourhood parts and no fallbacks', function(t) {
-    var query = new CoarseBooleanQuery();
+  test('county as most granular should only query county value across all coarse layers', function(t) {
+    var query = new GeodisambiguationQuery();
 
     var vs = new VariableStore();
     vs.var('size', 'size value');
@@ -140,7 +146,7 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.bool.should.length, 9);
+    t.equals(actual.query.bool.should.length, 10);
     t.deepEquals(actual.query.bool.should[0], individualLayer('neighbourhood',
         'coarse county value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
     t.deepEquals(actual.query.bool.should[1], individualLayer('borough',
@@ -157,7 +163,9 @@ module.exports.tests.base_render = function(test, common) {
         'coarse county value', ['parent.region', 'parent.region_a']));
     t.deepEquals(actual.query.bool.should[7], individualLayer('macroregion',
         'coarse county value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.bool.should[8], individualLayer('country',
+    t.deepEquals(actual.query.bool.should[8], individualLayer('dependency',
+        'coarse county value', ['parent.dependency', 'parent.dependency_a']));
+    t.deepEquals(actual.query.bool.should[9], individualLayer('country',
         'coarse county value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');
@@ -167,8 +175,8 @@ module.exports.tests.base_render = function(test, common) {
 
   });
 
-  test('VariableStore with region-only should only include neighbourhood parts and no fallbacks', function(t) {
-    var query = new CoarseBooleanQuery();
+  test('region as most granular should only query region value across all coarse layers', function(t) {
+    var query = new GeodisambiguationQuery();
 
     var vs = new VariableStore();
     vs.var('size', 'size value');
@@ -178,7 +186,7 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.bool.should.length, 9);
+    t.equals(actual.query.bool.should.length, 10);
     t.deepEquals(actual.query.bool.should[0], individualLayer('neighbourhood',
         'coarse region value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
     t.deepEquals(actual.query.bool.should[1], individualLayer('borough',
@@ -195,7 +203,9 @@ module.exports.tests.base_render = function(test, common) {
         'coarse region value', ['parent.region', 'parent.region_a']));
     t.deepEquals(actual.query.bool.should[7], individualLayer('macroregion',
         'coarse region value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.bool.should[8], individualLayer('country',
+    t.deepEquals(actual.query.bool.should[8], individualLayer('dependency',
+        'coarse region value', ['parent.dependency', 'parent.dependency_a']));
+    t.deepEquals(actual.query.bool.should[9], individualLayer('country',
         'coarse region value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');
@@ -205,8 +215,8 @@ module.exports.tests.base_render = function(test, common) {
 
   });
 
-  test('VariableStore with country-only should only include neighbourhood parts and no fallbacks', function(t) {
-    var query = new CoarseBooleanQuery();
+  test('country as most granular should only query country value across all coarse layers', function(t) {
+    var query = new GeodisambiguationQuery();
 
     var vs = new VariableStore();
     vs.var('size', 'size value');
@@ -215,7 +225,7 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.bool.should.length, 9);
+    t.equals(actual.query.bool.should.length, 10);
     t.deepEquals(actual.query.bool.should[0], individualLayer('neighbourhood',
         'coarse country value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
     t.deepEquals(actual.query.bool.should[1], individualLayer('borough',
@@ -232,7 +242,9 @@ module.exports.tests.base_render = function(test, common) {
         'coarse country value', ['parent.region', 'parent.region_a']));
     t.deepEquals(actual.query.bool.should[7], individualLayer('macroregion',
         'coarse country value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.bool.should[8], individualLayer('country',
+    t.deepEquals(actual.query.bool.should[8], individualLayer('dependency',
+        'coarse country value', ['parent.dependency', 'parent.dependency_a']));
+    t.deepEquals(actual.query.bool.should[9], individualLayer('country',
         'coarse country value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');


### PR DESCRIPTION
Fixes #38 

Since libpostal identifies territories and dependencies as `country`, this PR adds logic to query `parent.dependency` and `parent.dependency_a` for country values.  That is, libpostal parses Puerto Rico as country:

```
> puerto rico

Result:

{
  "country": "puerto rico"
}
```

The idea is to query the following fields for `Puerto Rico` in this case:  `country`, `country_a`, `dependency`, and `dependency_a`.  
