### PR TITLE
added scoring and filtering support

### DIFF
--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -28,10 +28,16 @@
 
 function Layout(){
   this._score = [];
+  this._filter = [];
 }
 
 Layout.prototype.score = function( view, operator ){
   this._score.push([ view, operator === 'must' ? 'must': 'should' ]);
+  return this;
+};
+
+Layout.prototype.filter = function( view ){
+  this._filter.push( view );
   return this;
 };
 
@@ -381,6 +387,19 @@ Layout.prototype.render = function( vs ){
           q.query.bool[ operator ] = [];
         }
         q.query.bool[ operator ].push( rendered );
+      }
+    });
+  }
+
+  // handle filter views under 'filter' section (only 'must' is allowed here)
+  if( this._filter.length ){
+    this._filter.forEach( function( view ){
+      var rendered = view( vs );
+      if( rendered ){
+        if( !q.query.bool.hasOwnProperty( 'filter' ) ){
+          q.query.bool.filter = [];
+        }
+        q.query.bool.filter.push( rendered );
       }
     });
   }

--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -371,6 +371,20 @@ Layout.prototype.render = function( vs ){
     q.query.bool.should.push(addCountry(vs));
   }
 
+  // handle scoring views under 'query' section (both 'must' & 'should')
+  if( this._score.length ){
+    this._score.forEach( function( condition ){
+      var view = condition[0], operator = condition[1];
+      var rendered = view( vs );
+      if( rendered ){
+        if( !q.query.bool.hasOwnProperty( operator ) ){
+          q.query.bool[ operator ] = [];
+        }
+        q.query.bool[ operator ].push( rendered );
+      }
+    });
+  }
+
   return q;
 };
 

--- a/layout/GeodisambiguationQuery.js
+++ b/layout/GeodisambiguationQuery.js
@@ -101,6 +101,20 @@ Layout.prototype.render = function( vs ){
   q.query.bool.should.push(addCoarseLayer('dependency', coarse_value));
   q.query.bool.should.push(addCoarseLayer('country', coarse_value));
 
+  // handle scoring views under 'query' section (both 'must' & 'should')
+  if( this._score.length ){
+    this._score.forEach( function( condition ){
+      var view = condition[0], operator = condition[1];
+      var rendered = view( vs );
+      if( rendered ){
+        if( !q.query.bool.hasOwnProperty( operator ) ){
+          q.query.bool[ operator ] = [];
+        }
+        q.query.bool[ operator ].push( rendered );
+      }
+    });
+  }
+
   return q;
 };
 

--- a/layout/GeodisambiguationQuery.js
+++ b/layout/GeodisambiguationQuery.js
@@ -40,10 +40,16 @@ var _ = require('lodash');
 
 function Layout(){
   this._score = [];
+  this._filter = [];
 }
 
 Layout.prototype.score = function( view, operator ){
   this._score.push([ view, operator === 'must' ? 'must': 'should' ]);
+  return this;
+};
+
+Layout.prototype.filter = function( view ){
+  this._filter.push( view );
   return this;
 };
 
@@ -111,6 +117,19 @@ Layout.prototype.render = function( vs ){
           q.query.bool[ operator ] = [];
         }
         q.query.bool[ operator ].push( rendered );
+      }
+    });
+  }
+
+  // handle filter views under 'filter' section (only 'must' is allowed here)
+  if( this._filter.length ){
+    this._filter.forEach( function( view ){
+      var rendered = view( vs );
+      if( rendered ){
+        if( !q.query.bool.hasOwnProperty( 'filter' ) ){
+          q.query.bool.filter = [];
+        }
+        q.query.bool.filter.push( rendered );
       }
     });
   }

--- a/test/layout/FallbackQuery.js
+++ b/test/layout/FallbackQuery.js
@@ -123,6 +123,172 @@ module.exports.tests.base_render = function(test, common) {
 
 };
 
+module.exports.tests.scores = function(test, common) {
+  test('score with operator specified should be honored and in order', function(t) {
+    var score_view1 = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field 1': 'score value 1' };
+    };
+
+    var score_view2 = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field 2': 'score value 2' };
+    };
+
+    var score_view3 = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field 3': 'score value 3' };
+    };
+
+    var score_view4 = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field 4': 'score value 4' };
+    };
+
+    var query = new FallbackQuery();
+    query.score(score_view1, 'must');
+    query.score(score_view2, 'should');
+    query.score(score_view3, 'must');
+    query.score(score_view4, 'should');
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+
+    var actual = query.render(vs);
+
+    var expected = {
+      query: {
+        bool: {
+          should: [
+            { 'score field 2': 'score value 2'},
+            { 'score field 4': 'score value 4'}
+          ],
+          must: [
+            { 'score field 1': 'score value 1'},
+            { 'score field 3': 'score value 3'}
+          ]
+        }
+      },
+      size: { $: 'size value' },
+      track_scores: { $: 'track_scores value' }
+    };
+
+    t.deepEquals(actual, expected);
+    t.end();
+
+  });
+
+  test('score without operator specified should be added as \'should\'', function(t) {
+    var score_view = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field': 'score value' };
+    };
+
+    var query = new FallbackQuery();
+    query.score(score_view);
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+
+    var actual = query.render(vs);
+
+    var expected = {
+      query: {
+        bool: {
+          should: [
+            { 'score field': 'score value'}
+          ]
+        }
+      },
+      size: { $: 'size value' },
+      track_scores: { $: 'track_scores value' }
+    };
+
+    t.deepEquals(actual, expected);
+    t.end();
+
+  });
+
+  test('score with non-must or -should operator specified should be added as \'should\'', function(t) {
+    var score_view = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field': 'score value' };
+    };
+
+    var query = new FallbackQuery();
+    query.score(score_view, 'non must or should value');
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+
+    var actual = query.render(vs);
+
+    var expected = {
+      query: {
+        bool: {
+          should: [
+            { 'score field': 'score value'}
+          ]
+        }
+      },
+      size: { $: 'size value' },
+      track_scores: { $: 'track_scores value' }
+    };
+
+    t.deepEquals(actual, expected);
+    t.end();
+
+  });
+
+  test('scores rendering to falsy values should not be added', function(t) {
+    var score_views_called = 0;
+
+    var query = new FallbackQuery();
+
+    [
+      { 'score field 1': 'score value 1' },
+      false, '', 0, null, undefined, NaN,
+      { 'score field 2': 'score value 2' },
+    ].forEach(function(value) {
+      query.score(function(vs) {
+        // assert that `vs` was actually passed
+        console.assert(vs !== null);
+        // make a note that the view was actually called
+        score_views_called++;
+        return value;
+      });
+    });
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+
+    var actual = query.render(vs);
+
+    var expected = {
+      query: {
+        bool: {
+          should: [
+            { 'score field 1': 'score value 1'},
+            { 'score field 2': 'score value 2'}
+          ]
+        }
+      },
+      size: { $: 'size value' },
+      track_scores: { $: 'track_scores value' }
+    };
+
+    t.deepEquals(actual, expected);
+    t.equals(score_views_called, 8);
+    t.end();
+
+  });
+
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('address ' + name, testFunction);

--- a/test/layout/FallbackQuery.js
+++ b/test/layout/FallbackQuery.js
@@ -289,6 +289,46 @@ module.exports.tests.scores = function(test, common) {
 
 };
 
+module.exports.tests.filter = function(test, common) {
+  test('all filter views returning truthy values should be added in order to sort', function(t) {
+    // the views assert that the VariableStore was passed, otherwise there's no
+    // guarantee that it was actually passed
+    var filter_views_called = 0;
+
+    var query = new FallbackQuery();
+
+    [
+      { 'filter field 1': 'filter value 1' },
+      false, '', 0, null, undefined, NaN,
+      { 'filter field 2': 'filter value 2' },
+    ].forEach(function(value) {
+      query.filter(function(vs) {
+        // assert that `vs` was actually passed
+        console.assert(vs !== null);
+        // make a note that the view was actually called
+        filter_views_called++;
+        return value;
+      });
+    });
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+
+    var actual = query.render(vs);
+
+    var expected_filter = [
+      { 'filter field 1': 'filter value 1'},
+      { 'filter field 2': 'filter value 2'}
+    ];
+
+    t.equals(filter_views_called, 8);
+    t.deepEquals(actual.query.bool.filter, expected_filter);
+    t.end();
+
+  });
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('address ' + name, testFunction);

--- a/test/layout/GeodisambiguationQuery.js
+++ b/test/layout/GeodisambiguationQuery.js
@@ -278,6 +278,148 @@ function individualLayer(layer, value, fields) {
 
 }
 
+module.exports.tests.scores = function(test, common) {
+  test('score with operator specified should be honored and in order', function(t) {
+    var score_view1 = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field 1': 'score value 1' };
+    };
+
+    var score_view2 = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field 2': 'score value 2' };
+    };
+
+    var score_view3 = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field 3': 'score value 3' };
+    };
+
+    var score_view4 = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field 4': 'score value 4' };
+    };
+
+    var query = new GeodisambiguationQuery();
+    query.score(score_view1, 'must');
+    query.score(score_view2, 'should');
+    query.score(score_view3, 'must');
+    query.score(score_view4, 'should');
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+
+    var actual = query.render(vs);
+    var actual_shoulds = actual.query.bool.should;
+    var actual_musts = actual.query.bool.must;
+
+    var expected_shoulds = [
+      { 'score field 2': 'score value 2'},
+      { 'score field 4': 'score value 4'}
+    ];
+
+    var expected_musts = [
+      { 'score field 1': 'score value 1'},
+      { 'score field 3': 'score value 3'}
+    ];
+
+    t.deepEquals(actual_shoulds.slice(actual_shoulds.length-2), expected_shoulds);
+    t.deepEquals(actual_musts.slice(actual_musts.length-2), expected_musts);
+
+    t.end();
+
+  });
+
+  test('score without operator specified should be added as \'should\'', function(t) {
+    var score_view = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field': 'score value' };
+    };
+
+    var query = new GeodisambiguationQuery();
+    query.score(score_view);
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+
+    var actual = query.render(vs);
+    var actual_shoulds = actual.query.bool.should;
+
+    var expected_shoulds = [
+      { 'score field': 'score value'}
+    ];
+
+    t.deepEquals(actual_shoulds.slice(actual_shoulds.length-1), expected_shoulds);
+    t.end();
+
+  });
+
+  test('score with non-must or -should operator specified should be added as \'should\'', function(t) {
+    var score_view = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field': 'score value' };
+    };
+
+    var query = new GeodisambiguationQuery();
+    query.score(score_view, 'non must or should value');
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+
+    var actual = query.render(vs);
+    var actual_shoulds = actual.query.bool.should;
+
+    var expected_shoulds = [
+      { 'score field': 'score value'}
+    ];
+
+    t.deepEquals(actual_shoulds.slice(actual_shoulds.length-1), expected_shoulds);
+    t.end();
+
+  });
+
+  test('scores rendering to falsy values should not be added', function(t) {
+    var score_views_called = 0;
+
+    var query = new GeodisambiguationQuery();
+
+    [
+      { 'score field 1': 'score value 1' },
+      false, '', 0, null, undefined, NaN,
+      { 'score field 2': 'score value 2' },
+    ].forEach(function(value) {
+      query.score(function(vs) {
+        // assert that `vs` was actually passed
+        console.assert(vs !== null);
+        // make a note that the view was actually called
+        score_views_called++;
+        return value;
+      });
+    });
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+
+    var actual = query.render(vs);
+    var actual_shoulds = actual.query.bool.should;
+
+    var expected_shoulds = [
+      { 'score field 1': 'score value 1'},
+      { 'score field 2': 'score value 2'}
+    ];
+
+    t.deepEquals(actual_shoulds.slice(actual_shoulds.length-2), expected_shoulds);
+    t.equals(score_views_called, 8);
+    t.end();
+
+  });
+
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('address ' + name, testFunction);

--- a/test/layout/GeodisambiguationQuery.js
+++ b/test/layout/GeodisambiguationQuery.js
@@ -420,6 +420,46 @@ module.exports.tests.scores = function(test, common) {
 
 };
 
+module.exports.tests.filter = function(test, common) {
+  test('all filter views returning truthy values should be added in order to sort', function(t) {
+    // the views assert that the VariableStore was passed, otherwise there's no
+    // guarantee that it was actually passed
+    var filter_views_called = 0;
+
+    var query = new GeodisambiguationQuery();
+
+    [
+      { 'filter field 1': 'filter value 1' },
+      false, '', 0, null, undefined, NaN,
+      { 'filter field 2': 'filter value 2' },
+    ].forEach(function(value) {
+      query.filter(function(vs) {
+        // assert that `vs` was actually passed
+        console.assert(vs !== null);
+        // make a note that the view was actually called
+        filter_views_called++;
+        return value;
+      });
+    });
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+
+    var actual = query.render(vs);
+
+    var expected_filter = [
+      { 'filter field 1': 'filter value 1'},
+      { 'filter field 2': 'filter value 2'}
+    ];
+
+    t.equals(filter_views_called, 8);
+    t.deepEquals(actual.query.bool.filter, expected_filter);
+    t.end();
+
+  });
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('address ' + name, testFunction);


### PR DESCRIPTION
This allows the API to add `score` and `filter` calls for things like focus point,  population/popularity, layers, and sources.  
