### PR TITLE
Optional postcode plus street layer

### DIFF
--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -261,6 +261,38 @@ function addHouseNumberAndStreet(vs) {
 
 }
 
+function addStreet(vs) {
+  var o = {
+    bool: {
+      _name: 'fallback.street',
+      must: [
+        {
+          match_phrase: {
+            'address_parts.street': vs.var('input:street').toString()
+          }
+        }
+      ],
+      should: [],
+      filter: {
+        term: {
+          layer: 'street'
+        }
+      }
+    }
+  };
+
+  addSecPostCode(vs, o);
+  addSecNeighbourhood(vs, o);
+  addSecBorough(vs, o);
+  addSecLocality(vs, o);
+  addSecCounty(vs, o);
+  addSecRegion(vs, o);
+  addSecCountry(vs, o);
+
+  return o;
+
+}
+
 function addNeighbourhood(vs) {
   var o = addPrimary(
     vs.var('input:neighbourhood').toString(),
@@ -436,6 +468,9 @@ Layout.prototype.render = function( vs ){
   }
   if (vs.isset('input:housenumber') && vs.isset('input:street')) {
     funcScoreShould.push(addHouseNumberAndStreet(vs));
+  }
+  if (vs.isset('input:street')) {
+    funcScoreShould.push(addStreet(vs));
   }
   if (vs.isset('input:neighbourhood')) {
     funcScoreShould.push(addNeighbourhood(vs));

--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -108,7 +108,7 @@ function addSecondary(value, fields) {
 function addSecPostCode(vs, o) {
   // add postcode if specified
   if (vs.isset('input:postcode')) {
-    o.bool.must.push({
+    o.bool.should.push({
       match_phrase: {
         'address_parts.zip': vs.var('input:postcode').toString()
       }
@@ -240,6 +240,7 @@ function addHouseNumberAndStreet(vs) {
           }
         }
       ],
+      should: [],
       filter: {
         term: {
           layer: 'address'

--- a/layout/baseQuery.js
+++ b/layout/baseQuery.js
@@ -15,6 +15,7 @@ module.exports = {
           }
         }
       },
+      // move to configuration
       max_boost: 20,
       functions: [],
       score_mode: 'avg',

--- a/test/fixtures/fallbackQuery1.json
+++ b/test/fixtures/fallbackQuery1.json
@@ -188,6 +188,92 @@
                 },
                 {
                   "bool": {
+                    "_name": "fallback.street",
+                    "must": [
+                      {
+                        "match_phrase": {
+                          "address_parts.street": "street value"
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "neighbourhood value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.neighbourhood",
+                            "parent.neighbourhood_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "borough value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.borough",
+                            "parent.borough_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "locality value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.locality",
+                            "parent.locality_a",
+                            "parent.localadmin",
+                            "parent.localadmin_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "should": [],
+                    "filter": {
+                      "term": {
+                        "layer": "street"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
                     "_name": "fallback.neighbourhood",
                     "must": [
                       {

--- a/test/fixtures/fallbackQuery1.json
+++ b/test/fixtures/fallbackQuery1.json
@@ -178,6 +178,7 @@
                         }
                       }
                     ],
+                    "should": [],
                     "filter": {
                       "term": {
                         "layer": "address"

--- a/test/fixtures/fallbackQuery2.json
+++ b/test/fixtures/fallbackQuery2.json
@@ -89,6 +89,7 @@
                         }
                       }
                     ],
+                    "should": [],
                     "filter": {
                       "term": {
                         "layer": "address"

--- a/test/fixtures/fallbackQuery2.json
+++ b/test/fixtures/fallbackQuery2.json
@@ -99,6 +99,92 @@
                 },
                 {
                   "bool": {
+                    "_name": "fallback.street",
+                    "must": [
+                      {
+                        "match_phrase": {
+                          "address_parts.street": "street value"
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "neighbourhood value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.neighbourhood",
+                            "parent.neighbourhood_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "borough value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.borough",
+                            "parent.borough_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "locality value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.locality",
+                            "parent.locality_a",
+                            "parent.localadmin",
+                            "parent.localadmin_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "should": [],
+                    "filter": {
+                      "term": {
+                        "layer": "street"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
                     "_name": "fallback.neighbourhood",
                     "must": [
                       {

--- a/test/fixtures/fallbackQuery_address_with_postcode.json
+++ b/test/fixtures/fallbackQuery_address_with_postcode.json
@@ -34,6 +34,30 @@
                       }
                     }
                   }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.street",
+                    "must": [
+                      {
+                        "match_phrase": {
+                          "address_parts.street": "street value"
+                        }
+                      }
+                    ],
+                    "should": [
+                      {
+                        "match_phrase": {
+                          "address_parts.zip": "postcode value"
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "street"
+                      }
+                    }
+                  }
                 }
               ]
             }

--- a/test/fixtures/fallbackQuery_address_with_postcode.json
+++ b/test/fixtures/fallbackQuery_address_with_postcode.json
@@ -19,7 +19,9 @@
                         "match_phrase": {
                           "address_parts.street": "street value"
                         }
-                      },
+                      }
+                    ],
+                    "should": [
                       {
                         "match_phrase": {
                           "address_parts.zip": "postcode value"


### PR DESCRIPTION
This PR adds support for querying by `street` layer and moves postalcode support to `should` condition instead of `must`.
