### PR TITLE
Remove population/popularity sort

### DIFF
--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -228,7 +228,7 @@ function addHouseNumberAndStreet(vs) {
   var o = {
     bool: {
       _name: 'fallback.address',
-      boost: 10,
+      boost: vs.var('boost:address').toString(),
       must: [
         {
           match_phrase: {
@@ -266,7 +266,7 @@ function addStreet(vs) {
   var o = {
     bool: {
       _name: 'fallback.street',
-      boost: 5,
+      boost: vs.var('boost:street').toString(),
       must: [
         {
           match_phrase: {

--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -228,6 +228,7 @@ function addHouseNumberAndStreet(vs) {
   var o = {
     bool: {
       _name: 'fallback.address',
+      boost: 10,
       must: [
         {
           match_phrase: {
@@ -265,6 +266,7 @@ function addStreet(vs) {
   var o = {
     bool: {
       _name: 'fallback.street',
+      boost: 5,
       must: [
         {
           match_phrase: {

--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -228,7 +228,7 @@ function addHouseNumberAndStreet(vs) {
   var o = {
     bool: {
       _name: 'fallback.address',
-      boost: vs.var('boost:address').toString(),
+      boost: vs.var('boost:address'),
       must: [
         {
           match_phrase: {
@@ -266,7 +266,7 @@ function addStreet(vs) {
   var o = {
     bool: {
       _name: 'fallback.street',
-      boost: vs.var('boost:street').toString(),
+      boost: vs.var('boost:street'),
       must: [
         {
           match_phrase: {

--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -228,7 +228,6 @@ function addHouseNumberAndStreet(vs) {
   var o = {
     bool: {
       _name: 'fallback.address',
-      boost: vs.var('boost:address'),
       must: [
         {
           match_phrase: {
@@ -250,6 +249,10 @@ function addHouseNumberAndStreet(vs) {
     }
   };
 
+  if (vs.isset('boost:address')) {
+    o.bool.boost = vs.var('boost:address');
+  }
+
   addSecPostCode(vs, o);
   addSecNeighbourhood(vs, o);
   addSecBorough(vs, o);
@@ -266,7 +269,6 @@ function addStreet(vs) {
   var o = {
     bool: {
       _name: 'fallback.street',
-      boost: vs.var('boost:street'),
       must: [
         {
           match_phrase: {
@@ -282,6 +284,10 @@ function addStreet(vs) {
       }
     }
   };
+
+  if (vs.isset('boost:street')) {
+    o.bool.boost = vs.var('boost:street');
+  }
 
   addSecPostCode(vs, o);
   addSecNeighbourhood(vs, o);

--- a/layout/baseQuery.js
+++ b/layout/baseQuery.js
@@ -23,16 +23,6 @@ module.exports = {
     }
   },
   sort: [
-    {
-      population: {
-        order: 'desc'
-      }
-    },
-    {
-      popularity: {
-        order: 'desc'
-      }
-    },
     '_score'
   ]
 };

--- a/test/fixtures/fallbackQuery1.json
+++ b/test/fixtures/fallbackQuery1.json
@@ -761,16 +761,6 @@
   "size": { "$": "size value" },
   "track_scores": { "$": "track_scores value" },
   "sort": [
-    {
-      "population": {
-        "order": "desc"
-      }
-    },
-    {
-      "popularity": {
-        "order": "desc"
-      }
-    },
     "_score"
   ]
 }

--- a/test/fixtures/fallbackQuery1.json
+++ b/test/fixtures/fallbackQuery1.json
@@ -98,7 +98,7 @@
                 {
                   "bool": {
                     "_name": "fallback.address",
-                    "boost": "boost:address value",
+                    "boost": { "$": 19 },
                     "must": [
                       {
                         "match_phrase": {
@@ -190,7 +190,7 @@
                 {
                   "bool": {
                     "_name": "fallback.street",
-                    "boost": "boost:street value",
+                    "boost": { "$": 17 },
                     "must": [
                       {
                         "match_phrase": {

--- a/test/fixtures/fallbackQuery1.json
+++ b/test/fixtures/fallbackQuery1.json
@@ -98,7 +98,7 @@
                 {
                   "bool": {
                     "_name": "fallback.address",
-                    "boost": 10,
+                    "boost": "boost:address value",
                     "must": [
                       {
                         "match_phrase": {
@@ -190,7 +190,7 @@
                 {
                   "bool": {
                     "_name": "fallback.street",
-                    "boost": 5,
+                    "boost": "boost:street value",
                     "must": [
                       {
                         "match_phrase": {

--- a/test/fixtures/fallbackQuery1.json
+++ b/test/fixtures/fallbackQuery1.json
@@ -98,6 +98,7 @@
                 {
                   "bool": {
                     "_name": "fallback.address",
+                    "boost": 10,
                     "must": [
                       {
                         "match_phrase": {
@@ -189,6 +190,7 @@
                 {
                   "bool": {
                     "_name": "fallback.street",
+                    "boost": 5,
                     "must": [
                       {
                         "match_phrase": {

--- a/test/fixtures/fallbackQuery2.json
+++ b/test/fixtures/fallbackQuery2.json
@@ -9,7 +9,7 @@
                 {
                   "bool": {
                     "_name": "fallback.address",
-                    "boost": "boost:address value",
+                    "boost": { "$": 19 },
                     "must": [
                       {
                         "match_phrase": {
@@ -101,7 +101,7 @@
                 {
                   "bool": {
                     "_name": "fallback.street",
-                    "boost": "boost:street value",
+                    "boost": { "$": 17 },
                     "must": [
                       {
                         "match_phrase": {

--- a/test/fixtures/fallbackQuery2.json
+++ b/test/fixtures/fallbackQuery2.json
@@ -9,7 +9,7 @@
                 {
                   "bool": {
                     "_name": "fallback.address",
-                    "boost": 10,
+                    "boost": "boost:address value",
                     "must": [
                       {
                         "match_phrase": {
@@ -101,7 +101,7 @@
                 {
                   "bool": {
                     "_name": "fallback.street",
-                    "boost": 5,
+                    "boost": "boost:street value",
                     "must": [
                       {
                         "match_phrase": {

--- a/test/fixtures/fallbackQuery2.json
+++ b/test/fixtures/fallbackQuery2.json
@@ -672,16 +672,6 @@
   "size": { "$": "size value" },
   "track_scores": { "$": "track_scores value" },
   "sort": [
-    {
-      "population": {
-        "order": "desc"
-      }
-    },
-    {
-      "popularity": {
-        "order": "desc"
-      }
-    },
     "_score"
   ]
 }

--- a/test/fixtures/fallbackQuery2.json
+++ b/test/fixtures/fallbackQuery2.json
@@ -9,6 +9,7 @@
                 {
                   "bool": {
                     "_name": "fallback.address",
+                    "boost": 10,
                     "must": [
                       {
                         "match_phrase": {
@@ -100,6 +101,7 @@
                 {
                   "bool": {
                     "_name": "fallback.street",
+                    "boost": 5,
                     "must": [
                       {
                         "match_phrase": {

--- a/test/fixtures/fallbackQuery_address_with_postcode.json
+++ b/test/fixtures/fallbackQuery_address_with_postcode.json
@@ -9,7 +9,7 @@
                 {
                   "bool": {
                     "_name": "fallback.address",
-                    "boost": 10,
+                    "boost": "boost:address value",
                     "must": [
                       {
                         "match_phrase": {
@@ -39,7 +39,7 @@
                 {
                   "bool": {
                     "_name": "fallback.street",
-                    "boost": 5,
+                    "boost": "boost:street value",
                     "must": [
                       {
                         "match_phrase": {

--- a/test/fixtures/fallbackQuery_address_with_postcode.json
+++ b/test/fixtures/fallbackQuery_address_with_postcode.json
@@ -78,16 +78,6 @@
   "size": { "$": "size value" },
   "track_scores": { "$": "track_scores value" },
   "sort": [
-    {
-      "population": {
-        "order": "desc"
-      }
-    },
-    {
-      "popularity": {
-        "order": "desc"
-      }
-    },
     "_score"
   ]
 }

--- a/test/fixtures/fallbackQuery_address_with_postcode.json
+++ b/test/fixtures/fallbackQuery_address_with_postcode.json
@@ -9,6 +9,7 @@
                 {
                   "bool": {
                     "_name": "fallback.address",
+                    "boost": 10,
                     "must": [
                       {
                         "match_phrase": {
@@ -38,6 +39,7 @@
                 {
                   "bool": {
                     "_name": "fallback.street",
+                    "boost": 5,
                     "must": [
                       {
                         "match_phrase": {

--- a/test/fixtures/fallbackQuery_address_with_postcode.json
+++ b/test/fixtures/fallbackQuery_address_with_postcode.json
@@ -9,7 +9,7 @@
                 {
                   "bool": {
                     "_name": "fallback.address",
-                    "boost": "boost:address value",
+                    "boost": { "$": 19 },
                     "must": [
                       {
                         "match_phrase": {
@@ -39,7 +39,7 @@
                 {
                   "bool": {
                     "_name": "fallback.street",
-                    "boost": "boost:street value",
+                    "boost": { "$": 17 },
                     "must": [
                       {
                         "match_phrase": {

--- a/test/fixtures/fallbackQuery_neighbourhood_only.json
+++ b/test/fixtures/fallbackQuery_neighbourhood_only.json
@@ -44,16 +44,6 @@
   "size": { "$": "size value" },
   "track_scores": { "$": "track_scores value" },
   "sort": [
-    {
-      "population": {
-        "order": "desc"
-      }
-    },
-    {
-      "popularity": {
-        "order": "desc"
-      }
-    },
     "_score"
   ]
 }

--- a/test/fixtures/fallbackQuery_nothing_set.json
+++ b/test/fixtures/fallbackQuery_nothing_set.json
@@ -24,16 +24,6 @@
   "size": { "$": "size value" },
   "track_scores": { "$": "track_scores value" },
   "sort": [
-    {
-      "population": {
-        "order": "desc"
-      }
-    },
-    {
-      "popularity": {
-        "order": "desc"
-      }
-    },
     "_score"
   ]
 }

--- a/test/layout/FallbackQuery.js
+++ b/test/layout/FallbackQuery.js
@@ -51,8 +51,8 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('input:county', 'county value');
     vs.var('input:region', 'region value');
     vs.var('input:country', 'country value');
-    vs.var('boost:address', 'boost:address value');
-    vs.var('boost:street', 'boost:street value');
+    vs.var('boost:address', 19);
+    vs.var('boost:street', 17);
 
     var actual = query.render(vs);
     var expected = require('../fixtures/fallbackQuery1.json');
@@ -76,8 +76,8 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('input:county', 'county value');
     vs.var('input:region', 'region value');
     vs.var('input:country', 'country value');
-    vs.var('boost:address', 'boost:address value');
-    vs.var('boost:street', 'boost:street value');
+    vs.var('boost:address', 19);
+    vs.var('boost:street', 17);
 
     var actual = query.render(vs);
     var expected = require('../fixtures/fallbackQuery2.json');
@@ -96,8 +96,8 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('input:housenumber', 'house number value');
     vs.var('input:street', 'street value');
     vs.var('input:postcode', 'postcode value');
-    vs.var('boost:address', 'boost:address value');
-    vs.var('boost:street', 'boost:street value');
+    vs.var('boost:address', 19);
+    vs.var('boost:street', 17);
 
     var fs = require('fs');
 

--- a/test/layout/FallbackQuery.js
+++ b/test/layout/FallbackQuery.js
@@ -51,6 +51,8 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('input:county', 'county value');
     vs.var('input:region', 'region value');
     vs.var('input:country', 'country value');
+    vs.var('boost:address', 'boost:address value');
+    vs.var('boost:street', 'boost:street value');
 
     var actual = query.render(vs);
     var expected = require('../fixtures/fallbackQuery1.json');
@@ -74,6 +76,8 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('input:county', 'county value');
     vs.var('input:region', 'region value');
     vs.var('input:country', 'country value');
+    vs.var('boost:address', 'boost:address value');
+    vs.var('boost:street', 'boost:street value');
 
     var actual = query.render(vs);
     var expected = require('../fixtures/fallbackQuery2.json');
@@ -92,6 +96,8 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('input:housenumber', 'house number value');
     vs.var('input:street', 'street value');
     vs.var('input:postcode', 'postcode value');
+    vs.var('boost:address', 'boost:address value');
+    vs.var('boost:street', 'boost:street value');
 
     var fs = require('fs');
 

--- a/test/layout/FallbackQuery.js
+++ b/test/layout/FallbackQuery.js
@@ -111,6 +111,26 @@ module.exports.tests.base_render = function(test, common) {
 
 };
 
+module.exports.tests.boosts = function(test, common) {
+  test('boost:street and boost:address missing from vs should not be include empty string', function(t) {
+    var query = new FallbackQuery();
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+    vs.var('input:housenumber', 'house number value');
+    vs.var('input:street', 'street value');
+
+    var actual = query.render(vs);
+
+    t.false(actual.query.function_score.query.filtered.query.bool.should[0].bool.hasOwnProperty('boost'));
+    t.false(actual.query.function_score.query.filtered.query.bool.should[1].bool.hasOwnProperty('boost'));
+    t.end();
+
+  });
+
+};
+
 module.exports.tests.scores = function(test, common) {
   test('scores rendering to falsy values should not be added', function(t) {
     var score_views_called = 0;


### PR DESCRIPTION
Fixes pelias/pelias#442

Removes useless population/popularity sort and adds `boost:address` and `boost:street` from VariableStore to ensure that `address` and `street` layer results aren't overshadowed by higher scoring common `locality` results.  
