### PR TITLE
modified ComponentFallbackQuery to use `number`/`street` fields

### DIFF
--- a/test/fixtures/componentFallbackQuery/address.json
+++ b/test/fixtures/componentFallbackQuery/address.json
@@ -11,6 +11,16 @@
                     "_name": "fallback.address",
                     "must": [
                       {
+                        "match_phrase": {
+                          "address_parts.number": "house number value"
+                        }
+                      },
+                      {
+                        "match_phrase": {
+                          "address_parts.street": "street value"
+                        }
+                      },
+                      {
                         "multi_match": {
                           "query": "neighbourhood value",
                           "type": "phrase",
@@ -81,22 +91,8 @@
                     ],
                     "should": [],
                     "filter": {
-                      "bool": {
-                        "must": [
-                          {
-                            "term": {
-                              "layer": "address"
-                            }
-                          },
-                          {
-                            "query_string": {
-                              "default_field": "name.default",
-                              "default_operator": "AND",
-                              "analyzer": "peliasQueryFullToken",
-                              "query": "address value"
-                            }
-                          }
-                        ]
+                      "term": {
+                        "layer": "address"
                       }
                     },
                     "boost": 50
@@ -108,7 +104,7 @@
                     "must": [
                       {
                         "match_phrase": {
-                          "address_parts.street": "address value"
+                          "address_parts.street": "street value"
                         }
                       },
                       {

--- a/test/fixtures/componentFallbackQuery/address_with_postcode.json
+++ b/test/fixtures/componentFallbackQuery/address_with_postcode.json
@@ -9,7 +9,18 @@
                 {
                   "bool": {
                     "_name": "fallback.address",
-                    "must": [],
+                    "must": [
+                      {
+                        "match_phrase": {
+                          "address_parts.number": "house number value"
+                        }
+                      },
+                      {
+                        "match_phrase": {
+                          "address_parts.street": "street value"
+                        }
+                      }
+                    ],
                     "should": [
                       {
                         "match_phrase": {
@@ -18,22 +29,8 @@
                       }
                     ],
                     "filter": {
-                      "bool": {
-                        "must": [
-                          {
-                            "term": {
-                              "layer": "address"
-                            }
-                          },
-                          {
-                            "query_string": {
-                              "default_field": "name.default",
-                              "default_operator": "AND",
-                              "analyzer": "peliasQueryFullToken",
-                              "query": "address value"
-                            }
-                          }
-                        ]
+                      "term": {
+                        "layer": "address"
                       }
                     },
                     "boost": 50
@@ -45,7 +42,7 @@
                     "must": [
                       {
                         "match_phrase": {
-                          "address_parts.street": "address value"
+                          "address_parts.street": "street value"
                         }
                       }
                     ],

--- a/test/layout/ComponentFallbackQuery.js
+++ b/test/layout/ComponentFallbackQuery.js
@@ -42,7 +42,8 @@ module.exports.tests.base_render = function(test, common) {
     var vs = new VariableStore();
     vs.var('size', 'size value');
     vs.var('track_scores', 'track_scores value');
-    vs.var('input:address', 'address value');
+    vs.var('input:housenumber', 'house number value');
+    vs.var('input:street', 'street value');
     vs.var('input:neighbourhood', 'neighbourhood value');
     vs.var('input:borough', 'borough value');
     vs.var('input:locality', 'locality value');
@@ -64,7 +65,8 @@ module.exports.tests.base_render = function(test, common) {
     var vs = new VariableStore();
     vs.var('size', 'size value');
     vs.var('track_scores', 'track_scores value');
-    vs.var('input:address', 'address value');
+    vs.var('input:housenumber', 'house number value');
+    vs.var('input:street', 'street value');
     vs.var('input:postcode', 'postcode value');
 
     var fs = require('fs');


### PR DESCRIPTION
With the introduction of libpostal in /component requests to parse the `address` field to extract a possible house number, it's now possible to query ES with the split fields instead of attempting magic with just the single address field.