### PR TITLE
added support for `query` value with test+fixture

### DIFF
--- a/layout/StructuredFallbackQuery.js
+++ b/layout/StructuredFallbackQuery.js
@@ -443,6 +443,9 @@ Layout.prototype.render = function( vs ){
 
   var funcScoreShould = q.query.function_score.query.filtered.query.bool.should;
 
+  if (vs.isset('input:query')) {
+    funcScoreShould.push(addQuery(vs));
+  }
   if (vs.isset('input:housenumber') && vs.isset('input:street')) {
     funcScoreShould.push(addHouseNumberAndStreet(vs));
   }

--- a/layout/StructuredFallbackQuery.js
+++ b/layout/StructuredFallbackQuery.js
@@ -168,7 +168,8 @@ function addQuery(vs) {
     vs.var('input:query').toString(),
     'venue',
     [
-      'phrase.default'
+      'phrase.default',
+      'category'
     ],
     false
   );

--- a/layout/StructuredFallbackQuery.js
+++ b/layout/StructuredFallbackQuery.js
@@ -446,10 +446,10 @@ Layout.prototype.render = function( vs ){
   if (vs.isset('input:query')) {
     funcScoreShould.push(addQuery(vs));
   }
-  if (vs.isset('input:housenumber') && vs.isset('input:street')) {
-    funcScoreShould.push(addHouseNumberAndStreet(vs));
-  }
   if (vs.isset('input:street')) {
+    if (vs.isset('input:housenumber')) {
+      funcScoreShould.push(addHouseNumberAndStreet(vs));
+    }
     funcScoreShould.push(addStreet(vs));
   }
   if (vs.isset('input:neighbourhood')) {

--- a/test/fixtures/structuredFallbackQuery/query.json
+++ b/test/fixtures/structuredFallbackQuery/query.json
@@ -15,7 +15,8 @@
                           "query": "query value",
                           "type": "phrase",
                           "fields": [
-                            "phrase.default"
+                            "phrase.default",
+                            "category"
                           ]
                         }
                       },

--- a/test/fixtures/structuredFallbackQuery/query.json
+++ b/test/fixtures/structuredFallbackQuery/query.json
@@ -1,0 +1,768 @@
+{
+  "query": {
+    "function_score": {
+      "query": {
+        "filtered": {
+          "query": {
+            "bool": {
+              "should": [
+                {
+                  "bool": {
+                    "_name": "fallback.venue",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "query value",
+                          "type": "phrase",
+                          "fields": [
+                            "phrase.default"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "neighbourhood value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.neighbourhood",
+                            "parent.neighbourhood_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "borough value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.borough",
+                            "parent.borough_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "locality value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.locality",
+                            "parent.locality_a",
+                            "parent.localadmin",
+                            "parent.localadmin_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "venue"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.address",
+                    "boost": { "$": 19 },
+                    "must": [
+                      {
+                        "match_phrase": {
+                          "address_parts.number": "house number value"
+                        }
+                      },
+                      {
+                        "match_phrase": {
+                          "address_parts.street": "street value"
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "neighbourhood value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.neighbourhood",
+                            "parent.neighbourhood_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "borough value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.borough",
+                            "parent.borough_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "locality value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.locality",
+                            "parent.locality_a",
+                            "parent.localadmin",
+                            "parent.localadmin_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "should": [],
+                    "filter": {
+                      "term": {
+                        "layer": "address"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.street",
+                    "boost": { "$": 17 },
+                    "must": [
+                      {
+                        "match_phrase": {
+                          "address_parts.street": "street value"
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "neighbourhood value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.neighbourhood",
+                            "parent.neighbourhood_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "borough value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.borough",
+                            "parent.borough_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "locality value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.locality",
+                            "parent.locality_a",
+                            "parent.localadmin",
+                            "parent.localadmin_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "should": [],
+                    "filter": {
+                      "term": {
+                        "layer": "street"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.neighbourhood",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "neighbourhood value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.neighbourhood",
+                            "parent.neighbourhood_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "borough value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.borough",
+                            "parent.borough_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "locality value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.locality",
+                            "parent.locality_a",
+                            "parent.localadmin",
+                            "parent.localadmin_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "neighbourhood"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.borough",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "borough value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.borough",
+                            "parent.borough_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "locality value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.locality",
+                            "parent.locality_a",
+                            "parent.localadmin",
+                            "parent.localadmin_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "borough"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.locality",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "locality value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.locality",
+                            "parent.locality_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "locality"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.localadmin",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "locality value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.localadmin",
+                            "parent.localadmin_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "localadmin"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.county",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "county"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.macrocounty",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "macrocounty"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.region",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "region"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.macroregion",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "region value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "macroregion"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.dependency",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "dependency"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.country",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "country"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "filter": {
+            "bool": {
+              "must": []
+            }
+          }
+        }
+      },
+      "max_boost": 20,
+      "functions": [],
+      "score_mode": "avg",
+      "boost_mode": "multiply"
+    }
+  },
+  "size": { "$": "size value" },
+  "track_scores": { "$": "track_scores value" },
+  "sort": [
+    "_score"
+  ]
+}

--- a/test/layout/StructuredFallbackQuery.js
+++ b/test/layout/StructuredFallbackQuery.js
@@ -61,6 +61,32 @@ module.exports.tests.base_render = function(test, common) {
 
   });
 
+  test('VariableStore with query and address fields should add query w/o address first', function(t) {
+    var query = new StructuredFallbackQuery();
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+    vs.var('input:query', 'query value');
+    vs.var('input:housenumber', 'house number value');
+    vs.var('input:street', 'street value');
+    vs.var('input:neighbourhood', 'neighbourhood value');
+    vs.var('input:borough', 'borough value');
+    vs.var('input:locality', 'locality value');
+    vs.var('input:county', 'county value');
+    vs.var('input:region', 'region value');
+    vs.var('input:country', 'country value');
+    vs.var('boost:address', 19);
+    vs.var('boost:street', 17);
+
+    var actual = query.render(vs);
+    var expected = require('../fixtures/structuredFallbackQuery/query.json');
+
+    t.deepEquals(actual, expected);
+    t.end();
+
+  });
+
   test('input:postcode set should include it at the address layer query', function(t) {
     var query = new StructuredFallbackQuery();
 


### PR DESCRIPTION
If a query and address fields (housenumber and street) are passed, the structured fallback will search for the query value without the address fields since otherwise it would search for the query at that exact address which isn't normally what the user wants to do.  For example:

```
{
  "query": "pizza",
  "housenumber": "1090",
  "street": "N Charlotte St",
  "locality": "Lancaster",
  "region": "PA"
}
```

The user isn't looking for pizza places literally at 1090 N Charlotte St, Lancaster, PA, they're looking for pizza *near* 1090 N Charlotte St, Lancaster, PA.  We can't do this until we have a 2 step process that geocodes location info first, then searches with the geocoded location as it's focus, so we have to search by dropping the address for now.  

From these parameters, the structured fallback will search the following ways:

* query=Pizza + locality=Lancaster + region=PA + layer=venue
* housenumber=1090 + street=N Charlotte St + locality=Lancaster + region=PA + layer=address
* street=N Charlotte St + locality=Lancaster + region=PA + layer=street
* locality=Lancaster + region=PA + layer=locality
* region=PA + layer=region

