### PR TITLE
ported to elasticsearch 5

### DIFF
--- a/examples/all_the_things.js
+++ b/examples/all_the_things.js
@@ -24,7 +24,7 @@ q.score( query.view.boundary_country, 'must' )
 
 // scoring boost
 q.score( query.view.phrase )
- .score( query.view.focus );
+ .score( query.view.focus( query.view.phrase ) );
 
 // address components
 q.score( query.view.address('housenumber') )

--- a/examples/local_priority_search.js
+++ b/examples/local_priority_search.js
@@ -17,7 +17,7 @@ var query = require('../index'),
 **/
 var q = new query.layout.FilteredBooleanQuery()
   .score( query.view.phrase )
-  .score( query.view.focus );
+  .score( query.view.focus( query.view.phrase ) );
 
 /**
   configure implementation-specific settings:

--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -491,7 +491,7 @@ function addPostCode(vs) {
 Layout.prototype.render = function( vs ){
   var q = Layout.base( vs );
 
-  var funcScoreShould = q.query.function_score.query.filtered.query.bool.should;
+  var funcScoreShould = q.query.function_score.query.bool.should;
 
   if (vs.isset('input:query')) {
     funcScoreShould.push(addQuery(vs));
@@ -543,7 +543,14 @@ Layout.prototype.render = function( vs ){
     this._filter.forEach( function( view ){
       var rendered = view( vs );
       if( rendered ){
-        q.query.function_score.query.filtered.filter.bool.must.push( rendered );
+        if( !q.query.function_score.query.bool.hasOwnProperty( 'filter' ) ){
+          q.query.function_score.query.bool.filter = {
+            bool: {
+              must: []
+            }
+          };
+        }
+        q.query.function_score.query.bool.filter.bool.must.push( rendered );
       }
     });
   }

--- a/layout/GeodisambiguationQuery.js
+++ b/layout/GeodisambiguationQuery.js
@@ -93,7 +93,7 @@ function getCoarseValue(vs) {
 
 Layout.prototype.render = function( vs ){
   var q = Layout.base( vs );
-  var funcScoreShould = q.query.function_score.query.filtered.query.bool.should;
+  var funcScoreShould = q.query.function_score.query.bool.should;
 
   var coarse_value = getCoarseValue(vs);
 
@@ -124,7 +124,14 @@ Layout.prototype.render = function( vs ){
     this._filter.forEach( function( view ){
       var rendered = view( vs );
       if( rendered ){
-        q.query.function_score.query.filtered.filter.bool.must.push( rendered );
+        if( !q.query.function_score.query.bool.hasOwnProperty( 'filter' ) ){
+          q.query.function_score.query.bool.filter = {
+            bool: {
+              must: []
+            }
+          };
+        }
+        q.query.function_score.query.bool.filter.bool.must.push( rendered );
       }
     });
   }

--- a/layout/StructuredFallbackQuery.js
+++ b/layout/StructuredFallbackQuery.js
@@ -464,7 +464,7 @@ function addPostCode(vs) {
 Layout.prototype.render = function( vs ){
   var q = Layout.base( vs );
 
-  var funcScoreShould = q.query.function_score.query.filtered.query.bool.should;
+  var funcScoreShould = q.query.function_score.query.bool.should;
 
   if (vs.isset('input:query')) {
     funcScoreShould.push(addQuery(vs));
@@ -519,7 +519,14 @@ Layout.prototype.render = function( vs ){
     this._filter.forEach( function( view ){
       var rendered = view( vs );
       if( rendered ){
-        q.query.function_score.query.filtered.filter.bool.must.push( rendered );
+        if( !q.query.function_score.query.bool.hasOwnProperty( 'filter' ) ){
+          q.query.function_score.query.bool.filter = {
+            bool: {
+              must: []
+            }
+          };
+        }
+        q.query.function_score.query.bool.filter.bool.must.push( rendered );
       }
     });
   }

--- a/layout/baseQuery.js
+++ b/layout/baseQuery.js
@@ -2,17 +2,8 @@ module.exports = {
   query: {
     function_score: {
       query: {
-        filtered: {
-          query: {
-            bool: {
-              should: []
-            }
-          },
-          filter: {
-            bool: {
-              must: []
-            }
-          }
+        bool: {
+          should: []
         }
       },
       // move to configuration

--- a/test/fixtures/fallbackQuery1.json
+++ b/test/fixtures/fallbackQuery1.json
@@ -2,756 +2,747 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": [
-                {
-                  "bool": {
-                    "_name": "fallback.venue",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "query value",
-                          "type": "phrase",
-                          "fields": [
-                            "phrase.default"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "venue"
-                      }
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.venue",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "query value",
+                      "type": "phrase",
+                      "fields": [
+                        "phrase.default"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
                     }
                   }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.address",
-                    "boost": { "$": 19 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.number": "house number value"
-                        }
-                      },
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "should": [],
-                    "filter": {
-                      "term": {
-                        "layer": "address"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.street",
-                    "boost": { "$": 17 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "should": [],
-                    "filter": {
-                      "term": {
-                        "layer": "street"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.neighbourhood",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "neighbourhood"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.borough",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "borough"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.locality",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "locality"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.localadmin",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "localadmin"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.county",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "county"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.macrocounty",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "macrocounty"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.region",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "region"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.macroregion",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "macroregion"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.dependency",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "dependency"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.country",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "country"
-                      }
-                    }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "venue"
                   }
                 }
-              ]
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.address",
+                "boost": { "$": 19 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.number": "house number value"
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "should": [],
+                "filter": {
+                  "term": {
+                    "layer": "address"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.street",
+                "boost": { "$": 17 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "should": [],
+                "filter": {
+                  "term": {
+                    "layer": "street"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.neighbourhood",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "neighbourhood"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.borough",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "borough"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.locality",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "locality"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.localadmin",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "localadmin"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.county",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "county"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macrocounty",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macrocounty"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.region",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "region"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macroregion",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macroregion"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.dependency",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "dependency"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.country",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "country"
+                  }
+                }
+              }
             }
-          },
-          "filter": {
-            "bool": {
-              "must": []
-            }
-          }
+          ]
         }
       },
       "max_boost": 20,

--- a/test/fixtures/fallbackQuery2.json
+++ b/test/fixtures/fallbackQuery2.json
@@ -2,667 +2,658 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": [
-                {
-                  "bool": {
-                    "_name": "fallback.address",
-                    "boost": { "$": 19 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.number": "house number value"
-                        }
-                      },
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "should": [],
-                    "filter": {
-                      "term": {
-                        "layer": "address"
-                      }
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.address",
+                "boost": { "$": 19 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.number": "house number value"
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
                     }
                   }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.street",
-                    "boost": { "$": 17 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "should": [],
-                    "filter": {
-                      "term": {
-                        "layer": "street"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.neighbourhood",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "neighbourhood"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.borough",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "borough"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.locality",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "locality"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.localadmin",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "localadmin"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.county",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "county"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.macrocounty",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "macrocounty"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.region",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "region"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.macroregion",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "macroregion"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.dependency",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "dependency"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.country",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "country"
-                      }
-                    }
+                ],
+                "should": [],
+                "filter": {
+                  "term": {
+                    "layer": "address"
                   }
                 }
-              ]
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.street",
+                "boost": { "$": 17 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "should": [],
+                "filter": {
+                  "term": {
+                    "layer": "street"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.neighbourhood",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "neighbourhood"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.borough",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "borough"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.locality",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "locality"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.localadmin",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "localadmin"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.county",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "county"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macrocounty",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macrocounty"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.region",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "region"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macroregion",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macroregion"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.dependency",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "dependency"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.country",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "country"
+                  }
+                }
+              }
             }
-          },
-          "filter": {
-            "bool": {
-              "must": []
-            }
-          }
+          ]
         }
       },
       "max_boost": 20,

--- a/test/fixtures/fallbackQuery_address_with_postcode.json
+++ b/test/fixtures/fallbackQuery_address_with_postcode.json
@@ -2,92 +2,83 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": [
-                {
-                  "bool": {
-                    "_name": "fallback.address",
-                    "boost": { "$": 19 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.number": "house number value"
-                        }
-                      },
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      }
-                    ],
-                    "should": [
-                      {
-                        "match_phrase": {
-                          "address_parts.zip": "postcode value"
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "address"
-                      }
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.address",
+                "boost": { "$": 19 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.number": "house number value"
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
                     }
                   }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.postalcode",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "postcode value",
-                          "type": "phrase",
-                          "fields": ["parent.postalcode"]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "postalcode"
-                      }
+                ],
+                "should": [
+                  {
+                    "match_phrase": {
+                      "address_parts.zip": "postcode value"
                     }
                   }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.street",
-                    "boost": { "$": 17 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      }
-                    ],
-                    "should": [
-                      {
-                        "match_phrase": {
-                          "address_parts.zip": "postcode value"
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "street"
-                      }
-                    }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "address"
                   }
                 }
-              ]
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.postalcode",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "postcode value",
+                      "type": "phrase",
+                      "fields": ["parent.postalcode"]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "postalcode"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.street",
+                "boost": { "$": 17 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  }
+                ],
+                "should": [
+                  {
+                    "match_phrase": {
+                      "address_parts.zip": "postcode value"
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "street"
+                  }
+                }
+              }
             }
-          },
-          "filter": {
-            "bool": {
-              "must": []
-            }
-          }
+          ]
         }
       },
       "max_boost": 20,

--- a/test/fixtures/fallbackQuery_neighbourhood_only.json
+++ b/test/fixtures/fallbackQuery_neighbourhood_only.json
@@ -2,37 +2,28 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": [
-                {
-                  "bool": {
-                    "_name": "fallback.neighbourhood",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": ["parent.neighbourhood", "parent.neighbourhood_a"]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "neighbourhood"
-                      }
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.neighbourhood",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": ["parent.neighbourhood", "parent.neighbourhood_a"]
                     }
                   }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "neighbourhood"
+                  }
                 }
-              ]
+              }
             }
-          },
-          "filter": {
-            "bool": {
-              "must": []
-            }
-          }
+          ]
         }
       },
       "max_boost": 20,

--- a/test/fixtures/fallbackQuery_nothing_set.json
+++ b/test/fixtures/fallbackQuery_nothing_set.json
@@ -2,17 +2,8 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": []
-            }
-          },
-          "filter": {
-            "bool": {
-              "must": []
-            }
-          }
+        "bool": {
+          "should": []
         }
       },
       "max_boost": 20,

--- a/test/fixtures/structuredFallbackQuery/address.json
+++ b/test/fixtures/structuredFallbackQuery/address.json
@@ -2,667 +2,658 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": [
-                {
-                  "bool": {
-                    "_name": "fallback.address",
-                    "boost": { "$": 19 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.number": "house number value"
-                        }
-                      },
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "should": [],
-                    "filter": {
-                      "term": {
-                        "layer": "address"
-                      }
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.address",
+                "boost": { "$": 19 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.number": "house number value"
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
                     }
                   }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.street",
-                    "boost": { "$": 17 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "should": [],
-                    "filter": {
-                      "term": {
-                        "layer": "street"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.neighbourhood",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "neighbourhood"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.borough",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "borough"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.locality",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "locality"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.localadmin",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "localadmin"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.county",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "county"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.macrocounty",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "macrocounty"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.region",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "region"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.macroregion",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "macroregion"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.dependency",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "dependency"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.country",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "country"
-                      }
-                    }
+                ],
+                "should": [],
+                "filter": {
+                  "term": {
+                    "layer": "address"
                   }
                 }
-              ]
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.street",
+                "boost": { "$": 17 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "should": [],
+                "filter": {
+                  "term": {
+                    "layer": "street"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.neighbourhood",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "neighbourhood"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.borough",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "borough"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.locality",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "locality"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.localadmin",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "localadmin"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.county",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "county"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macrocounty",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macrocounty"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.region",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "region"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macroregion",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macroregion"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.dependency",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "dependency"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.country",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "country"
+                  }
+                }
+              }
             }
-          },
-          "filter": {
-            "bool": {
-              "must": []
-            }
-          }
+          ]
         }
       },
       "max_boost": 20,

--- a/test/fixtures/structuredFallbackQuery/address_with_postcode.json
+++ b/test/fixtures/structuredFallbackQuery/address_with_postcode.json
@@ -2,92 +2,83 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": [
-                {
-                  "bool": {
-                    "_name": "fallback.address",
-                    "boost": { "$": 19 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.number": "house number value"
-                        }
-                      },
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      }
-                    ],
-                    "should": [
-                      {
-                        "match_phrase": {
-                          "address_parts.zip": "postcode value"
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "address"
-                      }
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.address",
+                "boost": { "$": 19 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.number": "house number value"
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
                     }
                   }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.street",
-                    "boost": { "$": 17 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      }
-                    ],
-                    "should": [
-                      {
-                        "match_phrase": {
-                          "address_parts.zip": "postcode value"
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "street"
-                      }
+                ],
+                "should": [
+                  {
+                    "match_phrase": {
+                      "address_parts.zip": "postcode value"
                     }
                   }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.postalcode",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "postcode value",
-                          "type": "phrase",
-                          "fields": ["parent.postalcode"]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "postalcode"
-                      }
-                    }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "address"
                   }
                 }
-              ]
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.street",
+                "boost": { "$": 17 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  }
+                ],
+                "should": [
+                  {
+                    "match_phrase": {
+                      "address_parts.zip": "postcode value"
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "street"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.postalcode",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "postcode value",
+                      "type": "phrase",
+                      "fields": ["parent.postalcode"]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "postalcode"
+                  }
+                }
+              }
             }
-          },
-          "filter": {
-            "bool": {
-              "must": []
-            }
-          }
+          ]
         }
       },
       "max_boost": 20,

--- a/test/fixtures/structuredFallbackQuery/locality_as_borough.json
+++ b/test/fixtures/structuredFallbackQuery/locality_as_borough.json
@@ -2,164 +2,155 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": [
-                {
-                  "bool": {
-                    "_name": "fallback.borough",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "borough"
-                      }
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.borough",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
                     }
                   }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.locality",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "locality"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.localadmin",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "localadmin"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.region",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "region"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.macroregion",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "macroregion"
-                      }
-                    }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "borough"
                   }
                 }
-              ]
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.locality",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "locality"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.localadmin",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "localadmin"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.region",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "region"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macroregion",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macroregion"
+                  }
+                }
+              }
             }
-          },
-          "filter": {
-            "bool": {
-              "must": []
-            }
-          }
+          ]
         }
       },
       "max_boost": 20,

--- a/test/fixtures/structuredFallbackQuery/query.json
+++ b/test/fixtures/structuredFallbackQuery/query.json
@@ -2,757 +2,748 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": [
-                {
-                  "bool": {
-                    "_name": "fallback.venue",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "query value",
-                          "type": "phrase",
-                          "fields": [
-                            "phrase.default",
-                            "category"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "venue"
-                      }
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.venue",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "query value",
+                      "type": "phrase",
+                      "fields": [
+                        "phrase.default",
+                        "category"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
                     }
                   }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.address",
-                    "boost": { "$": 19 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.number": "house number value"
-                        }
-                      },
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "should": [],
-                    "filter": {
-                      "term": {
-                        "layer": "address"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.street",
-                    "boost": { "$": 17 },
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "should": [],
-                    "filter": {
-                      "term": {
-                        "layer": "street"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.neighbourhood",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "neighbourhood"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.borough",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "borough"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.locality",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "locality"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.localadmin",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "locality value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "localadmin"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.county",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "county"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.macrocounty",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "macrocounty"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.region",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "region"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.macroregion",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "region value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "macroregion"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.dependency",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "dependency"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.country",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "country"
-                      }
-                    }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "venue"
                   }
                 }
-              ]
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.address",
+                "boost": { "$": 19 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.number": "house number value"
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "should": [],
+                "filter": {
+                  "term": {
+                    "layer": "address"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.street",
+                "boost": { "$": 17 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "should": [],
+                "filter": {
+                  "term": {
+                    "layer": "street"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.neighbourhood",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "neighbourhood"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.borough",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "borough"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.locality",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "locality"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.localadmin",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "locality value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "localadmin"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.county",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "county"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macrocounty",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macrocounty"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.region",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "region"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macroregion",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "region value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macroregion"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.dependency",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "dependency"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.country",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "country"
+                  }
+                }
+              }
             }
-          },
-          "filter": {
-            "bool": {
-              "must": []
-            }
-          }
+          ]
         }
       },
       "max_boost": 20,

--- a/test/layout/FallbackQuery.js
+++ b/test/layout/FallbackQuery.js
@@ -123,8 +123,8 @@ module.exports.tests.boosts = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.false(actual.query.function_score.query.filtered.query.bool.should[0].bool.hasOwnProperty('boost'));
-    t.false(actual.query.function_score.query.filtered.query.bool.should[1].bool.hasOwnProperty('boost'));
+    t.false(actual.query.function_score.query.bool.should[0].bool.hasOwnProperty('boost'));
+    t.false(actual.query.function_score.query.bool.should[1].bool.hasOwnProperty('boost'));
     t.end();
 
   });
@@ -210,7 +210,7 @@ module.exports.tests.filter = function(test, common) {
     ];
 
     t.equals(filter_views_called, 8);
-    t.deepEquals(actual.query.function_score.query.filtered.filter.bool.must, expected_filter);
+    t.deepEquals(actual.query.function_score.query.bool.filter.bool.must, expected_filter);
     t.end();
 
   });

--- a/test/layout/GeodisambiguationQuery.js
+++ b/test/layout/GeodisambiguationQuery.js
@@ -20,26 +20,26 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.function_score.query.filtered.query.bool.should.length, 10);
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[0], individualLayer('neighbourhood',
+    t.equals(actual.query.function_score.query.bool.should.length, 10);
+    t.deepEquals(actual.query.function_score.query.bool.should[0], individualLayer('neighbourhood',
         'coarse neighbourhood value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[1], individualLayer('borough',
+    t.deepEquals(actual.query.function_score.query.bool.should[1], individualLayer('borough',
         'coarse neighbourhood value', ['parent.borough', 'parent.borough_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[2], individualLayer('locality',
+    t.deepEquals(actual.query.function_score.query.bool.should[2], individualLayer('locality',
         'coarse neighbourhood value', ['parent.locality', 'parent.locality_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[3], individualLayer('localadmin',
+    t.deepEquals(actual.query.function_score.query.bool.should[3], individualLayer('localadmin',
         'coarse neighbourhood value', ['parent.localadmin', 'parent.localadmin_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[4], individualLayer('county',
+    t.deepEquals(actual.query.function_score.query.bool.should[4], individualLayer('county',
         'coarse neighbourhood value', ['parent.county', 'parent.county_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[5], individualLayer('macrocounty',
+    t.deepEquals(actual.query.function_score.query.bool.should[5], individualLayer('macrocounty',
         'coarse neighbourhood value', ['parent.macrocounty', 'parent.macrocounty_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[6], individualLayer('region',
+    t.deepEquals(actual.query.function_score.query.bool.should[6], individualLayer('region',
         'coarse neighbourhood value', ['parent.region', 'parent.region_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[7], individualLayer('macroregion',
+    t.deepEquals(actual.query.function_score.query.bool.should[7], individualLayer('macroregion',
         'coarse neighbourhood value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[8], individualLayer('dependency',
+    t.deepEquals(actual.query.function_score.query.bool.should[8], individualLayer('dependency',
         'coarse neighbourhood value', ['parent.dependency', 'parent.dependency_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[9], individualLayer('country',
+    t.deepEquals(actual.query.function_score.query.bool.should[9], individualLayer('country',
         'coarse neighbourhood value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');
@@ -63,26 +63,26 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.function_score.query.filtered.query.bool.should.length, 10);
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[0], individualLayer('neighbourhood',
+    t.equals(actual.query.function_score.query.bool.should.length, 10);
+    t.deepEquals(actual.query.function_score.query.bool.should[0], individualLayer('neighbourhood',
         'coarse borough value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[1], individualLayer('borough',
+    t.deepEquals(actual.query.function_score.query.bool.should[1], individualLayer('borough',
         'coarse borough value', ['parent.borough', 'parent.borough_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[2], individualLayer('locality',
+    t.deepEquals(actual.query.function_score.query.bool.should[2], individualLayer('locality',
         'coarse borough value', ['parent.locality', 'parent.locality_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[3], individualLayer('localadmin',
+    t.deepEquals(actual.query.function_score.query.bool.should[3], individualLayer('localadmin',
         'coarse borough value', ['parent.localadmin', 'parent.localadmin_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[4], individualLayer('county',
+    t.deepEquals(actual.query.function_score.query.bool.should[4], individualLayer('county',
         'coarse borough value', ['parent.county', 'parent.county_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[5], individualLayer('macrocounty',
+    t.deepEquals(actual.query.function_score.query.bool.should[5], individualLayer('macrocounty',
         'coarse borough value', ['parent.macrocounty', 'parent.macrocounty_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[6], individualLayer('region',
+    t.deepEquals(actual.query.function_score.query.bool.should[6], individualLayer('region',
         'coarse borough value', ['parent.region', 'parent.region_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[7], individualLayer('macroregion',
+    t.deepEquals(actual.query.function_score.query.bool.should[7], individualLayer('macroregion',
         'coarse borough value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[8], individualLayer('dependency',
+    t.deepEquals(actual.query.function_score.query.bool.should[8], individualLayer('dependency',
         'coarse borough value', ['parent.dependency', 'parent.dependency_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[9], individualLayer('country',
+    t.deepEquals(actual.query.function_score.query.bool.should[9], individualLayer('country',
         'coarse borough value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');
@@ -105,26 +105,26 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.function_score.query.filtered.query.bool.should.length, 10);
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[0], individualLayer('neighbourhood',
+    t.equals(actual.query.function_score.query.bool.should.length, 10);
+    t.deepEquals(actual.query.function_score.query.bool.should[0], individualLayer('neighbourhood',
         'coarse city value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[1], individualLayer('borough',
+    t.deepEquals(actual.query.function_score.query.bool.should[1], individualLayer('borough',
         'coarse city value', ['parent.borough', 'parent.borough_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[2], individualLayer('locality',
+    t.deepEquals(actual.query.function_score.query.bool.should[2], individualLayer('locality',
         'coarse city value', ['parent.locality', 'parent.locality_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[3], individualLayer('localadmin',
+    t.deepEquals(actual.query.function_score.query.bool.should[3], individualLayer('localadmin',
         'coarse city value', ['parent.localadmin', 'parent.localadmin_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[4], individualLayer('county',
+    t.deepEquals(actual.query.function_score.query.bool.should[4], individualLayer('county',
         'coarse city value', ['parent.county', 'parent.county_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[5], individualLayer('macrocounty',
+    t.deepEquals(actual.query.function_score.query.bool.should[5], individualLayer('macrocounty',
         'coarse city value', ['parent.macrocounty', 'parent.macrocounty_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[6], individualLayer('region',
+    t.deepEquals(actual.query.function_score.query.bool.should[6], individualLayer('region',
         'coarse city value', ['parent.region', 'parent.region_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[7], individualLayer('macroregion',
+    t.deepEquals(actual.query.function_score.query.bool.should[7], individualLayer('macroregion',
         'coarse city value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[8], individualLayer('dependency',
+    t.deepEquals(actual.query.function_score.query.bool.should[8], individualLayer('dependency',
         'coarse city value', ['parent.dependency', 'parent.dependency_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[9], individualLayer('country',
+    t.deepEquals(actual.query.function_score.query.bool.should[9], individualLayer('country',
         'coarse city value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');
@@ -146,26 +146,26 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.function_score.query.filtered.query.bool.should.length, 10);
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[0], individualLayer('neighbourhood',
+    t.equals(actual.query.function_score.query.bool.should.length, 10);
+    t.deepEquals(actual.query.function_score.query.bool.should[0], individualLayer('neighbourhood',
         'coarse county value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[1], individualLayer('borough',
+    t.deepEquals(actual.query.function_score.query.bool.should[1], individualLayer('borough',
         'coarse county value', ['parent.borough', 'parent.borough_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[2], individualLayer('locality',
+    t.deepEquals(actual.query.function_score.query.bool.should[2], individualLayer('locality',
         'coarse county value', ['parent.locality', 'parent.locality_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[3], individualLayer('localadmin',
+    t.deepEquals(actual.query.function_score.query.bool.should[3], individualLayer('localadmin',
         'coarse county value', ['parent.localadmin', 'parent.localadmin_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[4], individualLayer('county',
+    t.deepEquals(actual.query.function_score.query.bool.should[4], individualLayer('county',
         'coarse county value', ['parent.county', 'parent.county_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[5], individualLayer('macrocounty',
+    t.deepEquals(actual.query.function_score.query.bool.should[5], individualLayer('macrocounty',
         'coarse county value', ['parent.macrocounty', 'parent.macrocounty_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[6], individualLayer('region',
+    t.deepEquals(actual.query.function_score.query.bool.should[6], individualLayer('region',
         'coarse county value', ['parent.region', 'parent.region_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[7], individualLayer('macroregion',
+    t.deepEquals(actual.query.function_score.query.bool.should[7], individualLayer('macroregion',
         'coarse county value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[8], individualLayer('dependency',
+    t.deepEquals(actual.query.function_score.query.bool.should[8], individualLayer('dependency',
         'coarse county value', ['parent.dependency', 'parent.dependency_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[9], individualLayer('country',
+    t.deepEquals(actual.query.function_score.query.bool.should[9], individualLayer('country',
         'coarse county value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');
@@ -186,26 +186,26 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.function_score.query.filtered.query.bool.should.length, 10);
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[0], individualLayer('neighbourhood',
+    t.equals(actual.query.function_score.query.bool.should.length, 10);
+    t.deepEquals(actual.query.function_score.query.bool.should[0], individualLayer('neighbourhood',
         'coarse region value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[1], individualLayer('borough',
+    t.deepEquals(actual.query.function_score.query.bool.should[1], individualLayer('borough',
         'coarse region value', ['parent.borough', 'parent.borough_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[2], individualLayer('locality',
+    t.deepEquals(actual.query.function_score.query.bool.should[2], individualLayer('locality',
         'coarse region value', ['parent.locality', 'parent.locality_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[3], individualLayer('localadmin',
+    t.deepEquals(actual.query.function_score.query.bool.should[3], individualLayer('localadmin',
         'coarse region value', ['parent.localadmin', 'parent.localadmin_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[4], individualLayer('county',
+    t.deepEquals(actual.query.function_score.query.bool.should[4], individualLayer('county',
         'coarse region value', ['parent.county', 'parent.county_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[5], individualLayer('macrocounty',
+    t.deepEquals(actual.query.function_score.query.bool.should[5], individualLayer('macrocounty',
         'coarse region value', ['parent.macrocounty', 'parent.macrocounty_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[6], individualLayer('region',
+    t.deepEquals(actual.query.function_score.query.bool.should[6], individualLayer('region',
         'coarse region value', ['parent.region', 'parent.region_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[7], individualLayer('macroregion',
+    t.deepEquals(actual.query.function_score.query.bool.should[7], individualLayer('macroregion',
         'coarse region value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[8], individualLayer('dependency',
+    t.deepEquals(actual.query.function_score.query.bool.should[8], individualLayer('dependency',
         'coarse region value', ['parent.dependency', 'parent.dependency_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[9], individualLayer('country',
+    t.deepEquals(actual.query.function_score.query.bool.should[9], individualLayer('country',
         'coarse region value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');
@@ -225,26 +225,26 @@ module.exports.tests.base_render = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.equals(actual.query.function_score.query.filtered.query.bool.should.length, 10);
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[0], individualLayer('neighbourhood',
+    t.equals(actual.query.function_score.query.bool.should.length, 10);
+    t.deepEquals(actual.query.function_score.query.bool.should[0], individualLayer('neighbourhood',
         'coarse country value', ['parent.neighbourhood', 'parent.neighbourhood_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[1], individualLayer('borough',
+    t.deepEquals(actual.query.function_score.query.bool.should[1], individualLayer('borough',
         'coarse country value', ['parent.borough', 'parent.borough_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[2], individualLayer('locality',
+    t.deepEquals(actual.query.function_score.query.bool.should[2], individualLayer('locality',
         'coarse country value', ['parent.locality', 'parent.locality_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[3], individualLayer('localadmin',
+    t.deepEquals(actual.query.function_score.query.bool.should[3], individualLayer('localadmin',
         'coarse country value', ['parent.localadmin', 'parent.localadmin_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[4], individualLayer('county',
+    t.deepEquals(actual.query.function_score.query.bool.should[4], individualLayer('county',
         'coarse country value', ['parent.county', 'parent.county_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[5], individualLayer('macrocounty',
+    t.deepEquals(actual.query.function_score.query.bool.should[5], individualLayer('macrocounty',
         'coarse country value', ['parent.macrocounty', 'parent.macrocounty_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[6], individualLayer('region',
+    t.deepEquals(actual.query.function_score.query.bool.should[6], individualLayer('region',
         'coarse country value', ['parent.region', 'parent.region_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[7], individualLayer('macroregion',
+    t.deepEquals(actual.query.function_score.query.bool.should[7], individualLayer('macroregion',
         'coarse country value', ['parent.macroregion', 'parent.macroregion_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[8], individualLayer('dependency',
+    t.deepEquals(actual.query.function_score.query.bool.should[8], individualLayer('dependency',
         'coarse country value', ['parent.dependency', 'parent.dependency_a']));
-    t.deepEquals(actual.query.function_score.query.filtered.query.bool.should[9], individualLayer('country',
+    t.deepEquals(actual.query.function_score.query.bool.should[9], individualLayer('country',
         'coarse country value', ['parent.country', 'parent.country_a']));
 
     t.deepEquals(actual.size.toString(), 'size value');
@@ -357,7 +357,7 @@ module.exports.tests.filter = function(test, common) {
     ];
 
     t.equals(filter_views_called, 8);
-    t.deepEquals(actual.query.function_score.query.filtered.filter.bool.must, expected_filter);
+    t.deepEquals(actual.query.function_score.query.bool.filter.bool.must, expected_filter);
     t.end();
 
   });

--- a/test/layout/StructuredFallbackQuery.js
+++ b/test/layout/StructuredFallbackQuery.js
@@ -138,8 +138,8 @@ module.exports.tests.boosts = function(test, common) {
 
     var actual = query.render(vs);
 
-    t.false(actual.query.function_score.query.filtered.query.bool.should[0].bool.hasOwnProperty('boost'));
-    t.false(actual.query.function_score.query.filtered.query.bool.should[1].bool.hasOwnProperty('boost'));
+    t.false(actual.query.function_score.query.bool.should[0].bool.hasOwnProperty('boost'));
+    t.false(actual.query.function_score.query.bool.should[1].bool.hasOwnProperty('boost'));
     t.end();
 
   });
@@ -225,7 +225,7 @@ module.exports.tests.filter = function(test, common) {
     ];
 
     t.equals(filter_views_called, 8);
-    t.deepEquals(actual.query.function_score.query.filtered.filter.bool.must, expected_filter);
+    t.deepEquals(actual.query.function_score.query.bool.filter.bool.must, expected_filter);
     t.end();
 
   });


### PR DESCRIPTION
Hi,

We have ported the queries to ElasticSearch 5, we submit this pull request in case it can be of help.

The following has been performed:

- The `filtered` queries were replaced by `bool` queries, as explained in 
[Upgrade & Get Started > Filtered query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-filtered-query.html)

- Empty `filter` clauses were removed as they affect performance (tested on ElasticSearch 5.3).

-  Upgraded the affected tests.

Regards,