### PR TITLE
Fix: explicitly set minimum_should_match to 1

### DIFF
--- a/layout/baseQuery.js
+++ b/layout/baseQuery.js
@@ -3,6 +3,7 @@ module.exports = {
     function_score: {
       query: {
         bool: {
+          minimum_should_match: 1,
           should: []
         }
       },

--- a/test/fixtures/fallbackQuery1.json
+++ b/test/fixtures/fallbackQuery1.json
@@ -3,6 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/fallbackQuery2.json
+++ b/test/fixtures/fallbackQuery2.json
@@ -3,6 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/fallbackQuery_address_with_postcode.json
+++ b/test/fixtures/fallbackQuery_address_with_postcode.json
@@ -3,6 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/fallbackQuery_neighbourhood_only.json
+++ b/test/fixtures/fallbackQuery_neighbourhood_only.json
@@ -3,6 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/fallbackQuery_nothing_set.json
+++ b/test/fixtures/fallbackQuery_nothing_set.json
@@ -3,6 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
+          "minimum_should_match": 1,
           "should": []
         }
       },

--- a/test/fixtures/structuredFallbackQuery/address.json
+++ b/test/fixtures/structuredFallbackQuery/address.json
@@ -3,6 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/structuredFallbackQuery/address_with_postcode.json
+++ b/test/fixtures/structuredFallbackQuery/address_with_postcode.json
@@ -3,6 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/structuredFallbackQuery/locality_as_borough.json
+++ b/test/fixtures/structuredFallbackQuery/locality_as_borough.json
@@ -3,6 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/structuredFallbackQuery/query.json
+++ b/test/fixtures/structuredFallbackQuery/query.json
@@ -3,6 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {


### PR DESCRIPTION
A while back https://github.com/pelias/query/pull/61 changed all our queries to use Elasticsearch 5 compatible [bool queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-filtered-query.html) instead of the `filtered` queries that were deprecated in Elasticsearch 2, and no longer supported in Elasticsearch 5.

However, while the queries were supposed to behave identically, it appears that a `filtered` query effectively had a `minimum_should_match` setting of 1 implied, while the new queries have a `minimum_should_match` of 0 implied.

This was causing the new queries to return a bunch of irrelevant results, since any results that match the parent hierarchy filters would be returned, even if it did not match any of the should conditions.

Our query logic depended on `minimum_should_match` being set to 1, so it's now explicitly set.

Connects https://github.com/pelias/pelias/issues/461
Connects https://github.com/pelias/api/issues/762
Connects https://github.com/pelias/api/pull/855