### PR TITLE
Add fuzziness parameter support into ngram and phrase views

### DIFF
--- a/test/view/ngrams.js
+++ b/test/view/ngrams.js
@@ -63,6 +63,30 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
 
 };
 
+module.exports.tests.fuzziness_variable = function(test, common) {
+  test('fuzziness variable should be presented in query', function(t) {
+    var store = getBaseVariableStore();
+    store.var('ngram:fuzziness', 'fuzziness value');
+
+    var actual = ngrams(store);
+
+    var expected = {
+      match: {
+        'field value': {
+          analyzer: { $: 'analyzer value' },
+          boost: { $: 'boost value' },
+          query: { $: 'name value' },
+          fuzziness: { $: 'fuzziness value' }
+        }
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object with fuzziness field');
+    t.end();
+
+  });
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('ngrams ' + name, testFunction);

--- a/test/view/phrase.js
+++ b/test/view/phrase.js
@@ -66,6 +66,33 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
 
 };
 
+module.exports.tests.fuzziness_variable = function(test, common) {
+  test('fuzziness variable should be presented in query', function(t) {
+    var store = getBaseVariableStore();
+    store.var('phrase:fuzziness', 'fuzziness value');
+
+    var actual = phrase(store);
+
+    var expected = {
+      match: {
+        'field value': {
+          analyzer: { $: 'analyzer value' },
+          type: 'phrase',
+          boost: { $: 'boost value' },
+          slop: { $: 'slop value' },
+          query: { $: 'name value' },
+          fuzziness: { $: 'fuzziness value' }
+        }
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object with fuzziness field');
+    t.end();
+
+  });
+};
+
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('phrase ' + name, testFunction);

--- a/view/ngrams.js
+++ b/view/ngrams.js
@@ -19,5 +19,9 @@ module.exports = function( vs ){
     query: vs.var('input:name')
   };
 
+  if (vs.isset('ngram:fuzziness')) {
+    view.match[ vs.var('ngram:field') ].fuzziness = vs.var('ngram:fuzziness');
+  }
+
   return view;
 };

--- a/view/phrase.js
+++ b/view/phrase.js
@@ -22,5 +22,9 @@ module.exports = function( vs ){
     query: vs.var('input:name')
   };
 
+  if (vs.isset('phrase:fuzziness')) {
+    view.match[ vs.var('phrase:field') ].fuzziness = vs.var('phrase:fuzziness');
+  }
+
   return view;
 };


### PR DESCRIPTION
Relates to pelias/api#1038.

Link to ES documentation: https://www.elastic.co/guide/en/elasticsearch/guide/current/fuzzy-matching.html

long story short:
elasticsearch supports `fuzziness` parameter which (if was set up) tells search engine to match not only exact matches but also look for “fuzzily” similar words.

Possible values for this value "0..2" and "AUTO". This number is interpreted as Levenshtein edit distance.

The idea to set up this value not here (not in "pelias/query" module itself), but in "consumer" modules, such as "pelias/api".

At the same time it seems like a short-term solution which helps to find most obvious typos but unfortunately can't solve more complex problem. 