### PR TITLE
search with units only if units

### DIFF
--- a/test/fixtures/addressesUsingIdsQuery/housenumber_no_units.json
+++ b/test/fixtures/addressesUsingIdsQuery/housenumber_no_units.json
@@ -1,0 +1,54 @@
+{
+  "query": {
+    "function_score": {
+      "query": {
+        "bool": {
+          "minimum_number_should_match": 1,
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.street",
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "street"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.address",
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.number": "housenumber value"
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "address"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "size": "size value",
+  "track_scores": "track_scores value"
+}

--- a/test/fixtures/addressesUsingIdsQuery/unit_no_housenumber.json
+++ b/test/fixtures/addressesUsingIdsQuery/unit_no_housenumber.json
@@ -1,0 +1,32 @@
+{
+  "query": {
+    "function_score": {
+      "query": {
+        "bool": {
+          "minimum_number_should_match": 1,
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.street",
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "street"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "size": "size value",
+  "track_scores": "track_scores value"
+}

--- a/test/layout/AddressesUsingIdsQuery.js
+++ b/test/layout/AddressesUsingIdsQuery.js
@@ -99,6 +99,40 @@ module.exports.tests.base_render = (test, common) => {
 
   });
 
+  test('VariableStore with housenumber and no unit should not query on unit, only housenumbers', (t) => {
+    const query = new AddressesUsingIdsQuery();
+
+    const vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+    vs.var('input:housenumber', 'housenumber value');
+    vs.var('input:street', 'street value');
+
+    const actual = query.render(vs);
+    const expected = require('../fixtures/addressesUsingIdsQuery/housenumber_no_units.json');
+
+    // marshall/unmarshall to handle toString's internally
+    t.deepEquals(JSON.parse(JSON.stringify(actual)), expected);
+    t.end();
+
+  });
+  test('VariableStore with unit and no housenumber should neither query on the unit nor the housenumber, only the street', (t) => {
+    const query = new AddressesUsingIdsQuery();
+
+    const vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+    vs.var('input:unit', 'unit value');
+    vs.var('input:street', 'street value');
+
+    const actual = query.render(vs);
+    const expected = require('../fixtures/addressesUsingIdsQuery/unit_no_housenumber.json');
+
+    // marshall/unmarshall to handle toString's internally
+    t.deepEquals(JSON.parse(JSON.stringify(actual)), expected);
+    t.end();
+
+  });
 };
 
 module.exports.tests.render_with_scores = (test, common) => {


### PR DESCRIPTION
linked to https://github.com/pelias/pelias/issues/690

Note: is the query's `_name` important ?
I used the same `_name` for `createUnitAndAddressShould` and `createAddressShould` like it's done in https://github.com/pelias/query/blob/master/layout/StructuredFallbackQuery.js#L188 not sure if that's right