### PR TITLE
[WIP] match address parts using match_phrase_prefix instead of match_phrase

### DIFF
--- a/layout/AddressesUsingIdsQuery.js
+++ b/layout/AddressesUsingIdsQuery.js
@@ -9,17 +9,17 @@ function createAddressShould(vs) {
       _name: 'fallback.address',
       must: [
         {
-          match_phrase: {
+          match_phrase_prefix: {
             'address_parts.unit': vs.var('input:unit')
           }
         },
         {
-          match_phrase: {
+          match_phrase_prefix: {
             'address_parts.number': vs.var('input:housenumber')
           }
         },
         {
-          match_phrase: {
+          match_phrase_prefix: {
             'address_parts.street': vs.var('input:street')
           }
         }
@@ -46,7 +46,7 @@ function createStreetShould(vs) {
       _name: 'fallback.street',
       must: [
         {
-          match_phrase: {
+          match_phrase_prefix: {
             'address_parts.street': vs.var('input:street')
           }
         }

--- a/test/fixtures/addressesUsingIdsQuery/no_housenumber.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_housenumber.json
@@ -10,7 +10,7 @@
                 "_name": "fallback.street",
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/no_layers.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_layers.json
@@ -10,7 +10,7 @@
                 "_name": "fallback.street",
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }
@@ -27,17 +27,17 @@
                 "_name": "fallback.address",
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.unit": "unit value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.number": "housenumber value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/no_layers_with_boosts.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_layers_with_boosts.json
@@ -11,7 +11,7 @@
                 "boost": 19,
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }
@@ -29,17 +29,17 @@
                 "boost": 17,
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.unit": "unit value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.number": "housenumber value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/with_filters.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_filters.json
@@ -10,7 +10,7 @@
                 "_name": "fallback.street",
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }
@@ -27,17 +27,17 @@
                 "_name": "fallback.address",
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.unit": "unit value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.number": "housenumber value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/with_layers.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_layers.json
@@ -10,7 +10,7 @@
                 "_name": "fallback.street",
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }
@@ -27,17 +27,17 @@
                 "_name": "fallback.address",
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.unit": "unit value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.number": "housenumber value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/with_layers_and_filters.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_layers_and_filters.json
@@ -10,7 +10,7 @@
                 "_name": "fallback.street",
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }
@@ -27,17 +27,17 @@
                 "_name": "fallback.address",
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.unit": "unit value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.number": "housenumber value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/with_scores.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_scores.json
@@ -10,7 +10,7 @@
                 "_name": "fallback.street",
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }
@@ -27,17 +27,17 @@
                 "_name": "fallback.address",
                 "must": [
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.unit": "unit value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.number": "housenumber value"
                     }
                   },
                   {
-                    "match_phrase": {
+                    "match_phrase_prefix": {
                       "address_parts.street": "street value"
                     }
                   }


### PR DESCRIPTION
[do not merge]

I was looking in to https://github.com/pelias/pelias/issues/689 and discovered that we match address components using `match_phrase` (which I also thought was correct).

In the issue linked above, the user would like to be able to match streets using any form of:

- ул. Железнодорожная
- Железнодорожная
- улица Железнодорожная
- Железнодорожная улица

```
/v1/search?focus.point.lat=53&focus.point.lon=27&text=Железнодорожная улица 33
/v1/search?focus.point.lat=53&focus.point.lon=27&text=Железнодорожная 33
```

This PR is a bit crude but offers the ability to match while disregarding the suffix.

I'm not actually keen on merging this as-is but wanted to open up a PR to discuss the issue.

We need to also consider the effect it will have on other languages, such as for English this could possibly conflate `26 street east` with `26 street west`, depending on how it is implemented.

More testing will need to be added before anything like this can be merged.

Discuss!