### PR TITLE
Use cutoff_frequency everywhere

### DIFF
--- a/test/view/address.js
+++ b/test/view/address.js
@@ -7,6 +7,7 @@ function getBaseVariableStore(toExclude) {
   vs.var('address:asdf:analyzer', 'analyzer value');
   vs.var('address:asdf:field', 'field value');
   vs.var('address:asdf:boost', 'boost value');
+  vs.var('address:cutoff_frequency', 'cutoff_frequency value');
 
   if (toExclude) {
     vs.unset(toExclude);
@@ -34,6 +35,7 @@ module.exports.tests.no_property = function(test, common) {
     vs.var('address::analyzer', 'analyzer value');
     vs.var('address::field', 'field value');
     vs.var('address::boost', 'boost value');
+    vs.var('address:cutoff_frequency', 'cutoff_frequency value');
 
     var falseyPropertyAddress = require('../../view/address')('');
     var actual = address(vs);
@@ -49,6 +51,7 @@ module.exports.tests.no_property = function(test, common) {
     vs.var('address:0:analyzer', 'analyzer value');
     vs.var('address:0:field', 'field value');
     vs.var('address:0:boost', 'boost value');
+    vs.var('address:cutoff_frequency', 'cutoff_frequency value');
 
     var falseyPropertyAddress = require('../../view/address')(0);
     var actual = address(vs);
@@ -97,6 +100,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
     vs.var('address:asdf:analyzer', 'analyzer value');
     vs.var('address:asdf:field', 'field value');
     vs.var('address:asdf:boost', 'boost value');
+    vs.var('address:cutoff_frequency', 'cutoff_frequency value');
 
     var actual = address(vs);
 
@@ -108,6 +112,9 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           },
           boost: {
             $: 'boost value'
+          },
+          cutoff_frequency: {
+            $: 'cutoff_frequency value'
           },
           query: {
             $: 'input value'

--- a/test/view/address.js
+++ b/test/view/address.js
@@ -7,7 +7,6 @@ function getBaseVariableStore(toExclude) {
   vs.var('address:asdf:analyzer', 'analyzer value');
   vs.var('address:asdf:field', 'field value');
   vs.var('address:asdf:boost', 'boost value');
-  vs.var('address:asdf:cutoff_frequency', 'cutoff_frequency value');
 
   if (toExclude) {
     vs.unset(toExclude);

--- a/test/view/address.js
+++ b/test/view/address.js
@@ -7,7 +7,7 @@ function getBaseVariableStore(toExclude) {
   vs.var('address:asdf:analyzer', 'analyzer value');
   vs.var('address:asdf:field', 'field value');
   vs.var('address:asdf:boost', 'boost value');
-  vs.var('address:cutoff_frequency', 'cutoff_frequency value');
+  vs.var('address:asdf:cutoff_frequency', 'cutoff_frequency value');
 
   if (toExclude) {
     vs.unset(toExclude);
@@ -35,10 +35,10 @@ module.exports.tests.no_property = function(test, common) {
     vs.var('address::analyzer', 'analyzer value');
     vs.var('address::field', 'field value');
     vs.var('address::boost', 'boost value');
-    vs.var('address:cutoff_frequency', 'cutoff_frequency value');
+    vs.var('address::cutoff_frequency', 'cutoff_frequency value');
 
-    var falseyPropertyAddress = require('../../view/address')('');
-    var actual = address(vs);
+    var undefinedPropertyAddress = require('../../view/address')('');
+    var actual = undefinedPropertyAddress(vs);
 
     t.equal(actual, null, 'should have returned null');
     t.end();
@@ -51,10 +51,10 @@ module.exports.tests.no_property = function(test, common) {
     vs.var('address:0:analyzer', 'analyzer value');
     vs.var('address:0:field', 'field value');
     vs.var('address:0:boost', 'boost value');
-    vs.var('address:cutoff_frequency', 'cutoff_frequency value');
+    vs.var('address:0:cutoff_frequency', 'cutoff_frequency value');
 
-    var falseyPropertyAddress = require('../../view/address')(0);
-    var actual = address(vs);
+    var numericPropertyAddress = require('../../view/address')(0);
+    var actual = numericPropertyAddress(vs);
 
     t.equal(actual, null, 'should have returned null');
     t.end();
@@ -67,9 +67,10 @@ module.exports.tests.no_property = function(test, common) {
     vs.var('address:false:analyzer', 'analyzer value');
     vs.var('address:false:field', 'field value');
     vs.var('address:false:boost', 'boost value');
+    vs.var('address:false:cutoff_frequency', 'cutoff_frequency value');
 
     var falseyPropertyAddress = require('../../view/address')(false);
-    var actual = address(vs);
+    var actual = falseyPropertyAddress(vs);
 
     t.equal(actual, null, 'should have returned null');
     t.end();
@@ -100,7 +101,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
     vs.var('address:asdf:analyzer', 'analyzer value');
     vs.var('address:asdf:field', 'field value');
     vs.var('address:asdf:boost', 'boost value');
-    vs.var('address:cutoff_frequency', 'cutoff_frequency value');
+    vs.var('address:asdf:cutoff_frequency', 'cutoff_frequency value');
 
     var actual = address(vs);
 

--- a/test/view/admin.js
+++ b/test/view/admin.js
@@ -7,6 +7,7 @@ function getBaseVariableStore(toExclude) {
   vs.var('admin:asdf:analyzer', 'analyzer value');
   vs.var('admin:asdf:field', 'field value');
   vs.var('admin:asdf:boost', 'boost value');
+  vs.var('admin:cutoff_frequency', 'cutoff_frequency value');
 
   if (toExclude) {
     vs.unset(toExclude);
@@ -74,6 +75,9 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           },
           boost: {
             $: 'boost value'
+          },
+          cutoff_frequency: {
+            $: 'cutoff_frequency value'
           },
           query: {
             $: 'input value'

--- a/test/view/admin.js
+++ b/test/view/admin.js
@@ -7,7 +7,6 @@ function getBaseVariableStore(toExclude) {
   vs.var('admin:asdf:analyzer', 'analyzer value');
   vs.var('admin:asdf:field', 'field value');
   vs.var('admin:asdf:boost', 'boost value');
-  vs.var('admin:asdf:cutoff_frequency', 'cutoff_frequency value');
 
   if (toExclude) {
     vs.unset(toExclude);
@@ -76,6 +75,36 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           boost: {
             $: 'boost value'
           },
+          query: {
+            $: 'input value'
+          }
+        }
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+};
+
+module.exports.tests.cutoff_frequency = function(test, common) {
+  test('cutoff_frequency value used if provided', function(t) {
+    var vs = getBaseVariableStore();
+
+    vs.var('admin:asdf:cutoff_frequency', 'cutoff_frequency value');
+
+    var actual = admin(vs);
+
+    var expected = {
+      match: {
+        'field value': {
+          analyzer: {
+            $: 'analyzer value'
+          },
+          boost: {
+            $: 'boost value'
+          },
           cutoff_frequency: {
             $: 'cutoff_frequency value'
           },
@@ -90,7 +119,6 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
     t.end();
 
   });
-
 };
 
 module.exports.all = function (tape, common) {

--- a/test/view/admin.js
+++ b/test/view/admin.js
@@ -7,7 +7,7 @@ function getBaseVariableStore(toExclude) {
   vs.var('admin:asdf:analyzer', 'analyzer value');
   vs.var('admin:asdf:field', 'field value');
   vs.var('admin:asdf:boost', 'boost value');
-  vs.var('admin:cutoff_frequency', 'cutoff_frequency value');
+  vs.var('admin:asdf:cutoff_frequency', 'cutoff_frequency value');
 
   if (toExclude) {
     vs.unset(toExclude);

--- a/test/view/ngrams.js
+++ b/test/view/ngrams.js
@@ -7,6 +7,7 @@ function getBaseVariableStore(toExclude) {
   vs.var('ngram:analyzer', 'analyzer value');
   vs.var('ngram:field', 'field value');
   vs.var('ngram:boost', 'boost value');
+  vs.var('ngram:cutoff_frequency', 'cutoff_frequency value');
 
   if (toExclude) {
     vs.unset(toExclude);
@@ -51,6 +52,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
         'field value': {
           analyzer: { $: 'analyzer value' },
           boost: { $: 'boost value' },
+          cutoff_frequency: { $: 'cutoff_frequency value' },
           query: { $: 'name value' }
         }
       }
@@ -76,6 +78,7 @@ module.exports.tests.fuzziness_variable = function(test, common) {
           analyzer: { $: 'analyzer value' },
           boost: { $: 'boost value' },
           query: { $: 'name value' },
+          cutoff_frequency: { $: 'cutoff_frequency value' },
           fuzziness: { $: 'fuzziness value' }
         }
       }

--- a/test/view/ngrams.js
+++ b/test/view/ngrams.js
@@ -7,7 +7,6 @@ function getBaseVariableStore(toExclude) {
   vs.var('ngram:analyzer', 'analyzer value');
   vs.var('ngram:field', 'field value');
   vs.var('ngram:boost', 'boost value');
-  vs.var('ngram:cutoff_frequency', 'cutoff_frequency value');
 
   if (toExclude) {
     vs.unset(toExclude);
@@ -52,7 +51,6 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
         'field value': {
           analyzer: { $: 'analyzer value' },
           boost: { $: 'boost value' },
-          cutoff_frequency: { $: 'cutoff_frequency value' },
           query: { $: 'name value' }
         }
       }
@@ -78,13 +76,36 @@ module.exports.tests.fuzziness_variable = function(test, common) {
           analyzer: { $: 'analyzer value' },
           boost: { $: 'boost value' },
           query: { $: 'name value' },
-          cutoff_frequency: { $: 'cutoff_frequency value' },
           fuzziness: { $: 'fuzziness value' }
         }
       }
     };
 
     t.deepEquals(actual, expected, 'should have returned object with fuzziness field');
+    t.end();
+
+  });
+};
+
+module.exports.tests.cutoff_frequency = function(test, common) {
+  test('cutoff_frequency variable should be presented in query', function(t) {
+    var store = getBaseVariableStore();
+    store.var('ngram:cutoff_frequency', 'cutoff_frequency value');
+
+    var actual = ngrams(store);
+
+    var expected = {
+      match: {
+        'field value': {
+          analyzer: { $: 'analyzer value' },
+          boost: { $: 'boost value' },
+          query: { $: 'name value' },
+          cutoff_frequency: { $: 'cutoff_frequency value' }
+        }
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object with cutoff_frequency field');
     t.end();
 
   });

--- a/test/view/phrase.js
+++ b/test/view/phrase.js
@@ -8,6 +8,7 @@ function getBaseVariableStore(toExclude) {
   vs.var('phrase:field', 'field value');
   vs.var('phrase:boost', 'boost value');
   vs.var('phrase:slop', 'slop value');
+  vs.var('phrase:cutoff_frequency', 'cutoff_frequency value');
 
   if (toExclude) {
     vs.unset(toExclude);
@@ -54,6 +55,7 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           type: 'phrase',
           boost: { $: 'boost value' },
           slop: { $: 'slop value' },
+          cutoff_frequency: { $: 'cutoff_frequency value' },
           query: { $: 'name value' }
         }
       }
@@ -81,6 +83,7 @@ module.exports.tests.fuzziness_variable = function(test, common) {
           boost: { $: 'boost value' },
           slop: { $: 'slop value' },
           query: { $: 'name value' },
+          cutoff_frequency: { $: 'cutoff_frequency value' },
           fuzziness: { $: 'fuzziness value' }
         }
       }

--- a/test/view/phrase.js
+++ b/test/view/phrase.js
@@ -8,7 +8,6 @@ function getBaseVariableStore(toExclude) {
   vs.var('phrase:field', 'field value');
   vs.var('phrase:boost', 'boost value');
   vs.var('phrase:slop', 'slop value');
-  vs.var('phrase:cutoff_frequency', 'cutoff_frequency value');
 
   if (toExclude) {
     vs.unset(toExclude);
@@ -55,7 +54,6 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           type: 'phrase',
           boost: { $: 'boost value' },
           slop: { $: 'slop value' },
-          cutoff_frequency: { $: 'cutoff_frequency value' },
           query: { $: 'name value' }
         }
       }
@@ -83,13 +81,38 @@ module.exports.tests.fuzziness_variable = function(test, common) {
           boost: { $: 'boost value' },
           slop: { $: 'slop value' },
           query: { $: 'name value' },
-          cutoff_frequency: { $: 'cutoff_frequency value' },
           fuzziness: { $: 'fuzziness value' }
         }
       }
     };
 
     t.deepEquals(actual, expected, 'should have returned object with fuzziness field');
+    t.end();
+
+  });
+};
+
+module.exports.tests.cutoff_frequency = function(test, common) {
+  test('cutoff_frequency variable should be presented in query', function(t) {
+    var store = getBaseVariableStore();
+    store.var('phrase:cutoff_frequency', 'cutoff_frequency value');
+
+    var actual = phrase(store);
+
+    var expected = {
+      match: {
+        'field value': {
+          analyzer: { $: 'analyzer value' },
+          type: 'phrase',
+          boost: { $: 'boost value' },
+          slop: { $: 'slop value' },
+          query: { $: 'name value' },
+          cutoff_frequency: { $: 'cutoff_frequency value' }
+        }
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object with cutoff_frequency field');
     t.end();
 
   });

--- a/view/address.js
+++ b/view/address.js
@@ -12,6 +12,7 @@ module.exports = function( property ){
         !vs.isset('input:'+property) ||
         !vs.isset('address:'+property+':analyzer') ||
         !vs.isset('address:'+property+':field') ||
+        !vs.isset('address:cutoff_frequency') ||
         !vs.isset('address:'+property+':boost') ){
       return null;
     }
@@ -23,6 +24,7 @@ module.exports = function( property ){
     view.match[ vs.var('address:'+property+':field') ] = {
       analyzer: vs.var('address:'+property+':analyzer'),
       boost: vs.var('address:'+property+':boost'),
+      cutoff_frequency: vs.var('address:cutoff_frequency'),
       query: vs.var('input:'+property)
     };
 

--- a/view/address.js
+++ b/view/address.js
@@ -12,21 +12,24 @@ module.exports = function( property ){
         !vs.isset('input:'+property) ||
         !vs.isset('address:'+property+':analyzer') ||
         !vs.isset('address:'+property+':field') ||
-        !vs.isset('address:'+property+':cutoff_frequency') ||
         !vs.isset('address:'+property+':boost') ){
       return null;
     }
 
     // base view
-    var view = { 'match': {} };
+    let view = { 'match': {} };
 
     // match query
-    view.match[ vs.var('address:'+property+':field') ] = {
+    let section = view.match[ vs.var('address:'+property+':field') ] = {
       analyzer: vs.var('address:'+property+':analyzer'),
       boost: vs.var('address:'+property+':boost'),
-      cutoff_frequency: vs.var('address:'+property+':cutoff_frequency'),
       query: vs.var('input:'+property)
     };
+
+    // optional 'cutoff_frequency' property
+    if( vs.isset('address:'+property+':cutoff_frequency') ){
+      section.cutoff_frequency = vs.var('address:'+property+':cutoff_frequency');
+    }
 
     return view;
   };

--- a/view/address.js
+++ b/view/address.js
@@ -12,7 +12,7 @@ module.exports = function( property ){
         !vs.isset('input:'+property) ||
         !vs.isset('address:'+property+':analyzer') ||
         !vs.isset('address:'+property+':field') ||
-        !vs.isset('address:cutoff_frequency') ||
+        !vs.isset('address:'+property+':cutoff_frequency') ||
         !vs.isset('address:'+property+':boost') ){
       return null;
     }
@@ -24,7 +24,7 @@ module.exports = function( property ){
     view.match[ vs.var('address:'+property+':field') ] = {
       analyzer: vs.var('address:'+property+':analyzer'),
       boost: vs.var('address:'+property+':boost'),
-      cutoff_frequency: vs.var('address:cutoff_frequency'),
+      cutoff_frequency: vs.var('address:'+property+':cutoff_frequency'),
       query: vs.var('input:'+property)
     };
 

--- a/view/admin.js
+++ b/view/admin.js
@@ -12,6 +12,7 @@ module.exports = function( property ){
         !vs.isset('input:'+property) ||
         !vs.isset('admin:'+property+':analyzer') ||
         !vs.isset('admin:'+property+':field') ||
+        !vs.isset('admin:cutoff_frequency') ||
         !vs.isset('admin:'+property+':boost') ){
       return null;
     }
@@ -23,6 +24,7 @@ module.exports = function( property ){
     view.match[ vs.var('admin:'+property+':field') ] = {
       analyzer: vs.var('admin:'+property+':analyzer'),
       boost: vs.var('admin:'+property+':boost'),
+      cutoff_frequency: vs.var('admin:cutoff_frequency'),
       query: vs.var('input:'+property)
     };
 

--- a/view/admin.js
+++ b/view/admin.js
@@ -12,7 +12,7 @@ module.exports = function( property ){
         !vs.isset('input:'+property) ||
         !vs.isset('admin:'+property+':analyzer') ||
         !vs.isset('admin:'+property+':field') ||
-        !vs.isset('admin:cutoff_frequency') ||
+        !vs.isset('admin:'+property+':cutoff_frequency') ||
         !vs.isset('admin:'+property+':boost') ){
       return null;
     }
@@ -24,7 +24,7 @@ module.exports = function( property ){
     view.match[ vs.var('admin:'+property+':field') ] = {
       analyzer: vs.var('admin:'+property+':analyzer'),
       boost: vs.var('admin:'+property+':boost'),
-      cutoff_frequency: vs.var('admin:cutoff_frequency'),
+      cutoff_frequency: vs.var('admin:'+property+':cutoff_frequency'),
       query: vs.var('input:'+property)
     };
 

--- a/view/admin.js
+++ b/view/admin.js
@@ -12,21 +12,24 @@ module.exports = function( property ){
         !vs.isset('input:'+property) ||
         !vs.isset('admin:'+property+':analyzer') ||
         !vs.isset('admin:'+property+':field') ||
-        !vs.isset('admin:'+property+':cutoff_frequency') ||
         !vs.isset('admin:'+property+':boost') ){
       return null;
     }
 
     // base view
-    var view = { 'match': {} };
+    let view = { 'match': {} };
 
     // match query
-    view.match[ vs.var('admin:'+property+':field') ] = {
+    let section = view.match[ vs.var('admin:'+property+':field') ] = {
       analyzer: vs.var('admin:'+property+':analyzer'),
       boost: vs.var('admin:'+property+':boost'),
-      cutoff_frequency: vs.var('admin:'+property+':cutoff_frequency'),
       query: vs.var('input:'+property)
     };
+
+    // optional 'cutoff_frequency' property
+    if( vs.isset('admin:'+property+':cutoff_frequency') ){
+      section.cutoff_frequency = vs.var('admin:'+property+':cutoff_frequency');
+    }
 
     return view;
   };

--- a/view/ngrams.js
+++ b/view/ngrams.js
@@ -5,6 +5,7 @@ module.exports = function( vs ){
   if( !vs.isset('input:name') ||
       !vs.isset('ngram:analyzer') ||
       !vs.isset('ngram:field') ||
+      !vs.isset('ngram:cutoff_frequency') ||
       !vs.isset('ngram:boost') ){
     return null;
   }
@@ -16,6 +17,7 @@ module.exports = function( vs ){
   view.match[ vs.var('ngram:field') ] = {
     analyzer: vs.var('ngram:analyzer'),
     boost: vs.var('ngram:boost'),
+    cutoff_frequency: vs.var('ngram:cutoff_frequency'),
     query: vs.var('input:name')
   };
 

--- a/view/ngrams.js
+++ b/view/ngrams.js
@@ -5,7 +5,6 @@ module.exports = function( vs ){
   if( !vs.isset('input:name') ||
       !vs.isset('ngram:analyzer') ||
       !vs.isset('ngram:field') ||
-      !vs.isset('ngram:cutoff_frequency') ||
       !vs.isset('ngram:boost') ){
     return null;
   }
@@ -17,12 +16,15 @@ module.exports = function( vs ){
   view.match[ vs.var('ngram:field') ] = {
     analyzer: vs.var('ngram:analyzer'),
     boost: vs.var('ngram:boost'),
-    cutoff_frequency: vs.var('ngram:cutoff_frequency'),
     query: vs.var('input:name')
   };
 
   if (vs.isset('ngram:fuzziness')) {
     view.match[ vs.var('ngram:field') ].fuzziness = vs.var('ngram:fuzziness');
+  }
+
+  if (vs.isset('ngram:cutoff_frequency')) {
+    view.match[ vs.var('ngram:field') ].cutoff_frequency = vs.var('ngram:cutoff_frequency');
   }
 
   return view;

--- a/view/phrase.js
+++ b/view/phrase.js
@@ -6,6 +6,7 @@ module.exports = function( vs ){
       !vs.isset('phrase:analyzer') ||
       !vs.isset('phrase:field') ||
       !vs.isset('phrase:boost') ||
+      !vs.isset('phrase:cutoff_frequency') ||
       !vs.isset('phrase:slop') ){
     return null;
   }
@@ -19,6 +20,7 @@ module.exports = function( vs ){
     type: 'phrase',
     boost: vs.var('phrase:boost'),
     slop: vs.var('phrase:slop'),
+    cutoff_frequency: vs.var('phrase:cutoff_frequency'),
     query: vs.var('input:name')
   };
 

--- a/view/phrase.js
+++ b/view/phrase.js
@@ -6,7 +6,6 @@ module.exports = function( vs ){
       !vs.isset('phrase:analyzer') ||
       !vs.isset('phrase:field') ||
       !vs.isset('phrase:boost') ||
-      !vs.isset('phrase:cutoff_frequency') ||
       !vs.isset('phrase:slop') ){
     return null;
   }
@@ -20,12 +19,15 @@ module.exports = function( vs ){
     type: 'phrase',
     boost: vs.var('phrase:boost'),
     slop: vs.var('phrase:slop'),
-    cutoff_frequency: vs.var('phrase:cutoff_frequency'),
     query: vs.var('input:name')
   };
 
   if (vs.isset('phrase:fuzziness')) {
     view.match[ vs.var('phrase:field') ].fuzziness = vs.var('phrase:fuzziness');
+  }
+
+  if (vs.isset('phrase:cutoff_frequency')) {
+    view.match[ vs.var('phrase:field') ].cutoff_frequency = vs.var('phrase:cutoff_frequency');
   }
 
   return view;


### PR DESCRIPTION
Allow query views to set the [cutoff_frequency](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-match-query.html#query-dsl-match-query-cutoff) feature to support better performance on queries with lots of high-frequency terms.

See https://github.com/pelias/api/pull/1213 for more explanation on the use cases.