### PR TITLE
FilteredBooleanQuery: must_not

### DIFF
--- a/layout/FilteredBooleanQuery.js
+++ b/layout/FilteredBooleanQuery.js
@@ -6,7 +6,7 @@ function Layout(){
 }
 
 Layout.prototype.score = function( view, operator ){
-  this._score.push([ view, operator === 'must' ? 'must': 'should' ]);
+  this._score.push([ view, ( operator === 'must' || operator === 'must_not' ) ? operator: 'should' ]);
   return this;
 };
 
@@ -23,7 +23,7 @@ Layout.prototype.sort = function( view ){
 Layout.prototype.render = function( vs ){
   var q = Layout.base( vs );
 
-  // handle scoring views under 'query' section (both 'must' & 'should')
+  // handle scoring views under 'query' section (for 'must', 'must_not' & 'should')
   if( this._score.length ){
     this._score.forEach( function( condition ){
       var view = condition[0], operator = condition[1];

--- a/test/layout/FilteredBooleanQuery.js
+++ b/test/layout/FilteredBooleanQuery.js
@@ -51,11 +51,23 @@ module.exports.tests.scores = function(test, common) {
       return { 'score field 4': 'score value 4' };
     };
 
+    var score_view5 = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field 5': 'score value 5' };
+    };
+
+    var score_view6 = function(vs) {
+      console.assert(vs !== null);
+      return { 'score field 6': 'score value 6' };
+    };
+
     var query = new FilteredBooleanQuery();
     query.score(score_view1, 'must');
     query.score(score_view2, 'should');
-    query.score(score_view3, 'must');
-    query.score(score_view4, 'should');
+    query.score(score_view3, 'must_not');
+    query.score(score_view4, 'must');
+    query.score(score_view5, 'should');
+    query.score(score_view6, 'must_not');
 
     var vs = new VariableStore();
     vs.var('size', 'size value');
@@ -68,12 +80,16 @@ module.exports.tests.scores = function(test, common) {
         bool: {
           must: [
             { 'score field 1': 'score value 1'},
-            { 'score field 3': 'score value 3'}
+            { 'score field 4': 'score value 4'}
           ],
           should: [
             { 'score field 2': 'score value 2'},
-            { 'score field 4': 'score value 4'}
-          ]
+            { 'score field 5': 'score value 5'}
+          ],
+          must_not: [
+            { 'score field 3': 'score value 3'},
+            { 'score field 6': 'score value 6'}
+          ],
         }
       },
       size: { $: 'size value' },
@@ -119,7 +135,7 @@ module.exports.tests.scores = function(test, common) {
 
   });
 
-  test('score with non-must or -should operator specified should be added as \'should\'', function(t) {
+  test('score with non-must or -must_not or -should operator specified should be added as \'should\'', function(t) {
     var score_view = function(vs) {
       console.assert(vs !== null);
       return { 'score field': 'score value' };


### PR DESCRIPTION
This PR allows the FilteredBooleanQuery used by `/v1/autocomplete` to use any existing views as "must_not" conditions.

The syntax is a little odd IMHO, it would probably be more intuitive under `filter`, however ES deprecated the `not filter` command in favour of this approach:

```
The not query has been replaced by using a must_not clause in a bool query 
(see Bool Query).
```

```
must_not | The clause (query) must not appear in the matching documents. 
Clauses are executed in filter context meaning that scoring is ignored and 
clauses are considered for caching. Because scoring is ignored, a score of 0 
for all documents is returned.
```

- https://www.elastic.co/guide/en/elasticsearch/reference/6.3/query-dsl-bool-query.html
- https://www.elastic.co/guide/en/elasticsearch/reference/6.3/query-dsl-not-filter.html