### PR TITLE
improved sorting for addresses with matching postcode

### DIFF
--- a/test/fixtures/addressesUsingIdsQuery/no_layers.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_layers.json
@@ -28,6 +28,33 @@
                 "must": [
                   {
                     "match_phrase": {
+                      "address_parts.zip": "postcode value"
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "address_parts.number": "housenumber value"
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "address"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.address",
+                "must": [
+                  {
+                    "match_phrase": {
                       "address_parts.unit": "unit value"
                     }
                   },

--- a/test/layout/AddressesUsingIdsQuery.js
+++ b/test/layout/AddressesUsingIdsQuery.js
@@ -12,6 +12,7 @@ module.exports.tests.base_render = (test, common) => {
     vs.var('size', 'size value');
     vs.var('track_scores', 'track_scores value');
     vs.var('input:unit', 'unit value');
+    vs.var('input:postcode', 'postcode value');
     vs.var('input:housenumber', 'housenumber value');
     vs.var('input:street', 'street value');
 
@@ -123,6 +124,41 @@ module.exports.tests.base_render = (test, common) => {
     vs.var('size', 'size value');
     vs.var('track_scores', 'track_scores value');
     vs.var('input:unit', 'unit value');
+    vs.var('input:street', 'street value');
+
+    const actual = query.render(vs);
+    const expected = require('../fixtures/addressesUsingIdsQuery/unit_no_housenumber.json');
+
+    // marshall/unmarshall to handle toString's internally
+    t.deepEquals(JSON.parse(JSON.stringify(actual)), expected);
+    t.end();
+
+  });
+
+  test('VariableStore with housenumber and no postcode should not query on postcode, only housenumbers', (t) => {
+    const query = new AddressesUsingIdsQuery();
+
+    const vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+    vs.var('input:housenumber', 'housenumber value');
+    vs.var('input:street', 'street value');
+
+    const actual = query.render(vs);
+    const expected = require('../fixtures/addressesUsingIdsQuery/housenumber_no_units.json');
+
+    // marshall/unmarshall to handle toString's internally
+    t.deepEquals(JSON.parse(JSON.stringify(actual)), expected);
+    t.end();
+
+  });
+  test('VariableStore with postcode and no housenumber should neither query on the postcode nor the housenumber, only the street', (t) => {
+    const query = new AddressesUsingIdsQuery();
+
+    const vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+    vs.var('input:postcode', 'postcode value');
     vs.var('input:street', 'street value');
 
     const actual = query.render(vs);


### PR DESCRIPTION
I was alerted to this issue when investigating an issue of poor locality matching in Australia:

```
/v1/search?text=22 HENSON STREET, NSW, 2204

1) 22 Henson Street, Brighton-le-Sands, NSW, Australia
2) 22 Henson Street, Dulwich Hill, NSW, Australia
3) 22 Henson Street, Summer Hill (Ashfield), NSW, Australia
4) 22A Henson Street, Summer Hill (Ashfield), NSW, Australia
5) 22 Henson Street, Guildford, NSW, Australia
```

The issue is that the user supplied a postcode `2204` which was parsed correctly and matched record number 2.

If record 2. matched on the postcode, it should really be scored as no. 1

The reason for this is that the `address_search_using_ids` query doesn't include any boosting for postalcode matches.

This PR adds  an extra query clause for address queries which prioritises addresses with a matching postcode over others, so they sort higher.

```
/v1/search?text=233 ne 3rd ave, 97124

# before
1) 233 NE 3rd Ave, Canby, OR, USA (97013)
2) 233 NE 3rd Ave, Hillsboro, OR, USA (97124)

# after
1) 233 NE 3rd Ave, Hillsboro, OR, USA (97124)
2) 233 NE 3rd Ave, Canby, OR, USA (97013)
```
