### PR TITLE
CI and Node.js Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ jobs:
     - stage: release
       node_js: 10
       script: curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
-      if: branch = master
+      if: (branch = master) AND ( type = push )

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - 6
   - 8
   - 10
 matrix:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-development",
   "description": "An Elasticsearch query builder for Pelias",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Several changes regarding CI and Node.js versions
- Support for Node.js 6 has been dropped (https://github.com/pelias/pelias/issues/752)
- Semantic-release was running (doing nothing but taking up build time) on all pull requests for no reason