### PR TITLE
fix(structured): handle housenumber-only queries

### DIFF
--- a/layout/StructuredFallbackQuery.js
+++ b/layout/StructuredFallbackQuery.js
@@ -231,6 +231,41 @@ function addUnitAndHouseNumberAndStreet(vs) {
 
 }
 
+function addHouseNumber(vs) {
+  var o = {
+    bool: {
+      _name: 'fallback.housenumber',
+      must: [
+        {
+          match_phrase: {
+            'address_parts.number': vs.var('input:housenumber').toString()
+          }
+        }
+      ],
+      should: [],
+      filter: {
+        term: {
+          layer: 'address'
+        }
+      }
+    }
+  };
+
+  if (vs.isset('boost:address')) {
+    o.bool.boost = vs.var('boost:address');
+  }
+
+  addSecPostCode(vs, o);
+  addSecNeighbourhood(vs, o);
+  addSecBorough(vs, o);
+  addSecLocality(vs, o);
+  addSecCounty(vs, o);
+  addSecRegion(vs, o);
+  addSecCountry(vs, o);
+
+  return o;
+}
+
 function addHouseNumberAndStreet(vs) {
   var o = {
     bool: {
@@ -522,7 +557,10 @@ Layout.prototype.render = function( vs ){
       funcScoreShould.push(addHouseNumberAndStreet(vs));
     }
     funcScoreShould.push(addStreet(vs));
+  } else if (vs.isset('input:housenumber')) {
+      funcScoreShould.push(addHouseNumber(vs));
   }
+
   if (vs.isset('input:postcode')) {
     funcScoreShould.push(addPostCode(vs));
   }

--- a/test/fixtures/structuredFallbackQuery/housenumber.json
+++ b/test/fixtures/structuredFallbackQuery/housenumber.json
@@ -1,0 +1,41 @@
+{
+  "query": {
+    "function_score": {
+      "query": {
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.housenumber",
+                "boost": { "$": 19 },
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.number": "house number value"
+                    }
+                  }
+                ],
+                "should": [],
+                "filter": {
+                  "term": {
+                    "layer": "address"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "max_boost": 20,
+      "functions": [],
+      "score_mode": "avg",
+      "boost_mode": "multiply"
+    }
+  },
+  "size": { "$": "size value" },
+  "track_scores": { "$": "track_scores value" },
+  "sort": [
+    "_score"
+  ]
+}

--- a/test/layout/StructuredFallbackQuery.js
+++ b/test/layout/StructuredFallbackQuery.js
@@ -88,6 +88,22 @@ module.exports.tests.base_render = function(test, common) {
 
   });
 
+  test('VariableStore with only housenumber should create housenumber only query', function(t) {
+    var query = new StructuredFallbackQuery();
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('input:housenumber', 'house number value');
+    vs.var('track_scores', 'track_scores value');
+    vs.var('boost:address', 19);
+
+    var actual = query.render(vs);
+    var expected = require('../fixtures/structuredFallbackQuery/housenumber.json');
+
+    t.deepEquals(actual, expected);
+    t.end();
+  });
+
   test('input:postcode set should include it at the address layer query', function(t) {
     var query = new StructuredFallbackQuery();
 


### PR DESCRIPTION
In the case where libpostal parses a query that it believes only has a housenumber, an 'empty' query was being generated. These take a long time to run.