### PR TITLE
support type on multi_match queries

### DIFF
--- a/test/view/multi_match.js
+++ b/test/view/multi_match.js
@@ -91,6 +91,40 @@ module.exports.tests.cutoff_frequency = function (test, common) {
 
 };
 
+module.exports.tests.type = function (test, common) {
+  test('optional type', function (t) {
+    var vs = new VariableStore();
+    vs.var('query var', 'query value');
+    vs.var('multi_match:type', 'cross_fields');
+
+    var fields_with_boosts = [
+      { field: 'field 1' },
+      { field: 'field 2' },
+      { field: 'field 3' }
+    ];
+
+    var actual = multi_match(vs, fields_with_boosts, 'analyzer value', 'query var');
+
+    var expected = {
+      multi_match: {
+        fields: [
+          'field 1^1',
+          'field 2^1',
+          'field 3^1'
+        ],
+        query: { $: 'query value' },
+        analyzer: 'analyzer value',
+        type: { $: 'cross_fields' },
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object');
+    t.end();
+
+  });
+
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('multi_match ' + name, testFunction);

--- a/view/multi_match.js
+++ b/view/multi_match.js
@@ -31,6 +31,10 @@ module.exports = function( vs, fields_with_boosts, analyzer, query_var ){
   view.multi_match.query = vs.var(query_var);
   view.multi_match.analyzer = analyzer;
 
+  if (vs.isset('multi_match:type')) {
+    view.multi_match.type = vs.var('multi_match:type');
+  }
+
   if (vs.isset('multi_match:cutoff_frequency')) {
     view.multi_match.cutoff_frequency = vs.var('multi_match:cutoff_frequency');
   }


### PR DESCRIPTION
support `type` on multi_match queries

ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#multi-match-types

cc/ @joxit this might be useful for you