### PR TITLE
feat(query): Use full form for match_phrase query

### DIFF
--- a/layout/AddressesUsingIdsQuery.js
+++ b/layout/AddressesUsingIdsQuery.js
@@ -10,12 +10,16 @@ function createAddressShould(vs) {
       must: [
         {
           match_phrase: {
-            'address_parts.number': vs.var('input:housenumber')
+            'address_parts.number': {
+              query: vs.var('input:housenumber')
+            }
           }
         },
         {
           match_phrase: {
-            'address_parts.street': vs.var('input:street')
+            'address_parts.street': {
+              query: vs.var('input:street')
+            }
           }
         }
       ],
@@ -41,17 +45,23 @@ function createUnitAndAddressShould(vs) {
       must: [
         {
           match_phrase: {
-            'address_parts.unit': vs.var('input:unit')
+            'address_parts.unit': {
+              query: vs.var('input:unit')
+            }
           }
         },
         {
           match_phrase: {
-            'address_parts.number': vs.var('input:housenumber')
+            'address_parts.number': {
+              query: vs.var('input:housenumber')
+            }
           }
         },
         {
           match_phrase: {
-            'address_parts.street': vs.var('input:street')
+            'address_parts.street': {
+              query: vs.var('input:street')
+            }
           }
         }
       ],
@@ -77,17 +87,23 @@ function createPostcodeAndAddressShould(vs) {
       must: [
         {
           match_phrase: {
-            'address_parts.zip': vs.var('input:postcode')
+            'address_parts.zip': {
+              query: vs.var('input:postcode')
+            }
           }
         },
         {
           match_phrase: {
-            'address_parts.number': vs.var('input:housenumber')
+            'address_parts.number': {
+              query: vs.var('input:housenumber')
+            }
           }
         },
         {
           match_phrase: {
-            'address_parts.street': vs.var('input:street')
+            'address_parts.street': {
+              query: vs.var('input:street')
+            }
           }
         }
       ],
@@ -113,7 +129,9 @@ function createStreetShould(vs) {
       must: [
         {
           match_phrase: {
-            'address_parts.street': vs.var('input:street')
+            'address_parts.street': {
+              query: vs.var('input:street')
+            }
           }
         }
       ],

--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -80,7 +80,9 @@ function addPrimary(value, layer, fields, likely_to_have_abbreviation) {
   //   o.bool.must.push(
   //     {
   //       match_phrase: {
-  //         'phrase.default': value
+  //         'phrase.default': {
+  //           query: value
+  //         }
   //       }
   //     }
   //   );
@@ -110,7 +112,9 @@ function addSecPostCode(vs, o) {
   if (vs.isset('input:postcode')) {
     o.bool.should.push({
       match_phrase: {
-        'address_parts.zip': vs.var('input:postcode').toString()
+        'address_parts.zip': {
+          query: vs.var('input:postcode').toString()
+        }
       }
     });
   }
@@ -231,17 +235,23 @@ function addUnitAndHouseNumberAndStreet(vs) {
       must: [
         {
           match_phrase: {
-            'address_parts.unit': vs.var('input:unit').toString()
+            'address_parts.unit': {
+              query: vs.var('input:unit').toString()
+            }
           }
         },
         {
           match_phrase: {
-            'address_parts.number': vs.var('input:housenumber').toString()
+            'address_parts.number': {
+              query: vs.var('input:housenumber').toString()
+            }
           }
         },
         {
           match_phrase: {
-            'address_parts.street': vs.var('input:street').toString()
+            'address_parts.street': {
+              query: vs.var('input:street').toString()
+            }
           }
         }
       ],
@@ -277,12 +287,16 @@ function addHouseNumberAndStreet(vs) {
       must: [
         {
           match_phrase: {
-            'address_parts.number': vs.var('input:housenumber').toString()
+            'address_parts.number': {
+              query: vs.var('input:housenumber').toString()
+            }
           }
         },
         {
           match_phrase: {
-            'address_parts.street': vs.var('input:street').toString()
+            'address_parts.street': {
+              query: vs.var('input:street').toString()
+            }
           }
         }
       ],
@@ -318,7 +332,9 @@ function addStreet(vs) {
       must: [
         {
           match_phrase: {
-            'address_parts.street': vs.var('input:street').toString()
+            'address_parts.street': {
+              query: vs.var('input:street').toString()
+            }
           }
         }
       ],

--- a/layout/StructuredFallbackQuery.js
+++ b/layout/StructuredFallbackQuery.js
@@ -70,7 +70,9 @@ function addSecPostCode(vs, o) {
   if (vs.isset('input:postcode')) {
     o.bool.should.push({
       match_phrase: {
-        'address_parts.zip': vs.var('input:postcode').toString()
+        'address_parts.zip': {
+          query: vs.var('input:postcode').toString()
+        }
       }
     });
   }
@@ -192,17 +194,23 @@ function addUnitAndHouseNumberAndStreet(vs) {
       must: [
         {
           match_phrase: {
-            'address_parts.unit': vs.var('input:unit').toString()
+            'address_parts.unit': {
+              query: vs.var('input:unit').toString()
+            }
           }
         },
         {
           match_phrase: {
-            'address_parts.number': vs.var('input:housenumber').toString()
+            'address_parts.number': {
+              query: vs.var('input:housenumber').toString()
+            }
           }
         },
         {
           match_phrase: {
-            'address_parts.street': vs.var('input:street').toString()
+            'address_parts.street': {
+              query: vs.var('input:street').toString()
+            }
           }
         }
       ],
@@ -238,7 +246,9 @@ function addHouseNumber(vs) {
       must: [
         {
           match_phrase: {
-            'address_parts.number': vs.var('input:housenumber').toString()
+            'address_parts.number': {
+              query: vs.var('input:housenumber').toString()
+            }
           }
         }
       ],
@@ -273,12 +283,16 @@ function addHouseNumberAndStreet(vs) {
       must: [
         {
           match_phrase: {
-            'address_parts.number': vs.var('input:housenumber').toString()
+            'address_parts.number': {
+              query: vs.var('input:housenumber').toString()
+            }
           }
         },
         {
           match_phrase: {
-            'address_parts.street': vs.var('input:street').toString()
+            'address_parts.street': {
+              query: vs.var('input:street').toString()
+            }
           }
         }
       ],
@@ -314,7 +328,9 @@ function addStreet(vs) {
       must: [
         {
           match_phrase: {
-            'address_parts.street': vs.var('input:street').toString()
+            'address_parts.street': {
+              query: vs.var('input:street').toString()
+            }
           }
         }
       ],

--- a/test/fixtures/addressesUsingIdsQuery/housenumber_no_units.json
+++ b/test/fixtures/addressesUsingIdsQuery/housenumber_no_units.json
@@ -11,7 +11,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
@@ -28,12 +30,16 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.number": "housenumber value"
+                      "address_parts.number": {
+                        "query": "housenumber value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/addressesUsingIdsQuery/no_housenumber.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_housenumber.json
@@ -11,7 +11,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/addressesUsingIdsQuery/no_layers.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_layers.json
@@ -11,7 +11,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
@@ -28,17 +30,23 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.zip": "postcode value"
+                      "address_parts.zip": {
+                        "query": "postcode value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.number": "housenumber value"
+                      "address_parts.number": {
+                        "query": "housenumber value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
@@ -55,17 +63,23 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.unit": "unit value"
+                      "address_parts.unit": {
+                        "query": "unit value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.number": "housenumber value"
+                      "address_parts.number": {
+                        "query": "housenumber value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/addressesUsingIdsQuery/no_layers_with_boosts.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_layers_with_boosts.json
@@ -12,7 +12,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
@@ -30,17 +32,23 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.unit": "unit value"
+                      "address_parts.unit": {
+                        "query": "unit value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.number": "housenumber value"
+                      "address_parts.number": {
+                        "query": "housenumber value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/addressesUsingIdsQuery/unit_no_housenumber.json
+++ b/test/fixtures/addressesUsingIdsQuery/unit_no_housenumber.json
@@ -11,7 +11,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/addressesUsingIdsQuery/with_filters.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_filters.json
@@ -11,7 +11,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
@@ -28,17 +30,23 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.unit": "unit value"
+                      "address_parts.unit": {
+                        "query": "unit value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.number": "housenumber value"
+                      "address_parts.number": {
+                        "query": "housenumber value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/addressesUsingIdsQuery/with_layers.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_layers.json
@@ -11,7 +11,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
@@ -28,17 +30,23 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.unit": "unit value"
+                      "address_parts.unit": {
+                        "query": "unit value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.number": "housenumber value"
+                      "address_parts.number": {
+                        "query": "housenumber value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/addressesUsingIdsQuery/with_layers_and_filters.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_layers_and_filters.json
@@ -11,7 +11,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
@@ -28,17 +30,23 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.unit": "unit value"
+                      "address_parts.unit": {
+                        "query": "unit value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.number": "housenumber value"
+                      "address_parts.number": {
+                        "query": "housenumber value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/addressesUsingIdsQuery/with_scores.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_scores.json
@@ -11,7 +11,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
@@ -28,17 +30,23 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.unit": "unit value"
+                      "address_parts.unit": {
+                        "query": "unit value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.number": "housenumber value"
+                      "address_parts.number": {
+                        "query": "housenumber value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/fallbackQuery1.json
+++ b/test/fixtures/fallbackQuery1.json
@@ -101,17 +101,23 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.unit": "unit value"
+                      "address_parts.unit": {
+                        "query": "unit value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.number": "house number value"
+                      "address_parts.number": {
+                        "query": "house number value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   },
                   {
@@ -198,7 +204,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   },
                   {

--- a/test/fixtures/fallbackQuery2.json
+++ b/test/fixtures/fallbackQuery2.json
@@ -12,12 +12,16 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.number": "house number value"
+                      "address_parts.number": {
+                        "query": "house number value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   },
                   {
@@ -104,7 +108,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   },
                   {

--- a/test/fixtures/fallbackQuery_address_with_postcode.json
+++ b/test/fixtures/fallbackQuery_address_with_postcode.json
@@ -12,19 +12,25 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.number": "house number value"
+                      "address_parts.number": {
+                        "query": "house number value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
                 "should": [
                   {
                     "match_phrase": {
-                      "address_parts.zip": "postcode value"
+                      "address_parts.zip": {
+                        "query": "postcode value"
+                      }
                     }
                   }
                 ],
@@ -61,14 +67,18 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
                 "should": [
                   {
                     "match_phrase": {
-                      "address_parts.zip": "postcode value"
+                      "address_parts.zip": {
+                        "query": "postcode value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/structuredFallbackQuery/address.json
+++ b/test/fixtures/structuredFallbackQuery/address.json
@@ -12,17 +12,23 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.unit": "unit value"
+                      "address_parts.unit": {
+                        "query": "unit value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.number": "house number value"
+                      "address_parts.number": {
+                        "query": "house number value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   },
                   {
@@ -109,7 +115,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   },
                   {

--- a/test/fixtures/structuredFallbackQuery/address_with_postcode.json
+++ b/test/fixtures/structuredFallbackQuery/address_with_postcode.json
@@ -12,19 +12,25 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.number": "house number value"
+                      "address_parts.number": {
+                        "query": "house number value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
                 "should": [
                   {
                     "match_phrase": {
-                      "address_parts.zip": "postcode value"
+                      "address_parts.zip": {
+                        "query": "postcode value"
+                      }
                     }
                   }
                 ],
@@ -42,14 +48,18 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   }
                 ],
                 "should": [
                   {
                     "match_phrase": {
-                      "address_parts.zip": "postcode value"
+                      "address_parts.zip": {
+                        "query": "postcode value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/structuredFallbackQuery/housenumber.json
+++ b/test/fixtures/structuredFallbackQuery/housenumber.json
@@ -12,7 +12,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.number": "house number value"
+                      "address_parts.number": {
+                        "query": "house number value"
+                      }
                     }
                   }
                 ],

--- a/test/fixtures/structuredFallbackQuery/query.json
+++ b/test/fixtures/structuredFallbackQuery/query.json
@@ -102,12 +102,16 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.number": "house number value"
+                      "address_parts.number": {
+                        "query": "house number value"
+                      }
                     }
                   },
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   },
                   {
@@ -194,7 +198,9 @@
                 "must": [
                   {
                     "match_phrase": {
-                      "address_parts.street": "street value"
+                      "address_parts.street": {
+                        "query": "street value"
+                      }
                     }
                   },
                   {


### PR DESCRIPTION
There are two forms for the Elasticsearch [match_phrase](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html) query:

1. A shorter, condensed version which does not allow setting extra options:
```
{
  "match_phrase": {
    "the-field": "the search terms"
  }
}
```

2. A complete version that does allow setting options:
```
{
  "match_phrase": {
    "the-field": {
      "query": "the search terms",
      "some-option": "some-value"
    }
  }
}
```

Pelias currently uses a mix of the two formats. This change removes all usage of the condensed format in favor of the full format.

As a pure refactoring, with no functional changes, this should be safe to merge immediately. However, it will make it easier to add new options to phrase queries (such as `slop`) in the future.