### PR TITLE
feat(addressUsingIdsQuery): Add slop parameter

### DIFF
--- a/layout/AddressesUsingIdsQuery.js
+++ b/layout/AddressesUsingIdsQuery.js
@@ -18,7 +18,8 @@ function createAddressShould(vs) {
         {
           match_phrase: {
             'address_parts.street': {
-              query: vs.var('input:street')
+              query: vs.var('input:street'),
+              slop: vs.var('address:street:slop')
             }
           }
         }
@@ -60,7 +61,8 @@ function createUnitAndAddressShould(vs) {
         {
           match_phrase: {
             'address_parts.street': {
-              query: vs.var('input:street')
+              query: vs.var('input:street'),
+              slop: vs.var('address:street:slop')
             }
           }
         }
@@ -102,7 +104,8 @@ function createPostcodeAndAddressShould(vs) {
         {
           match_phrase: {
             'address_parts.street': {
-              query: vs.var('input:street')
+              query: vs.var('input:street'),
+              slop: vs.var('address:street:slop')
             }
           }
         }
@@ -130,7 +133,8 @@ function createStreetShould(vs) {
         {
           match_phrase: {
             'address_parts.street': {
-              query: vs.var('input:street')
+              query: vs.var('input:street'),
+              slop: vs.var('address:street:slop')
             }
           }
         }
@@ -191,6 +195,11 @@ class AddressesUsingIdsQuery extends Query {
     }
     else if (vs.isset('input:housenumber')) {
       base.query.function_score.query.bool.should.push(createAddressShould(vs));
+    }
+
+    // default address:street:slop to 0 if unset
+    if (!vs.isset('address:street:slop')) {
+      vs.var('address:street:slop', 0);
     }
 
     // if there are layer->id mappings, add the layers with non-empty ids

--- a/test/fixtures/addressesUsingIdsQuery/housenumber_no_units.json
+++ b/test/fixtures/addressesUsingIdsQuery/housenumber_no_units.json
@@ -12,7 +12,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }
@@ -38,7 +39,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/no_housenumber.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_housenumber.json
@@ -12,7 +12,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/no_layers.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_layers.json
@@ -12,7 +12,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }
@@ -45,7 +46,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }
@@ -78,7 +80,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/no_layers_with_boosts.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_layers_with_boosts.json
@@ -13,7 +13,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }
@@ -47,7 +48,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/unit_no_housenumber.json
+++ b/test/fixtures/addressesUsingIdsQuery/unit_no_housenumber.json
@@ -12,7 +12,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/with_filters.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_filters.json
@@ -12,7 +12,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }
@@ -45,7 +46,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/with_layers.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_layers.json
@@ -12,7 +12,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }
@@ -45,7 +46,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/with_layers_and_filters.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_layers_and_filters.json
@@ -12,7 +12,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }
@@ -45,7 +46,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }

--- a/test/fixtures/addressesUsingIdsQuery/with_scores.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_scores.json
@@ -12,7 +12,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }
@@ -45,7 +46,8 @@
                   {
                     "match_phrase": {
                       "address_parts.street": {
-                        "query": "street value"
+                        "query": "street value",
+                        "slop": 0
                       }
                     }
                   }


### PR DESCRIPTION
This adds support for the `match_phrase` [slop parameter](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html).

The default is set to 0, so as it stands, this addition will not change the outcome of any queries.