### PR TITLE
feat(geo_distance): Remove deprecated optimize_bbox parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,6 @@ results in a query such as:
           "geo_distance": {
             "distance": "5km",
             "distance_type": "plane",
-            "optimize_bbox": "indexed",
             "center_point": {
               "lat": 51.5,
               "lon": -0.06

--- a/defaults.json
+++ b/defaults.json
@@ -10,7 +10,6 @@
 
   "boundary:circle:radius": "50km",
   "boundary:circle:distance_type": "plane",
-  "boundary:circle:optimize_bbox": "indexed",
 
   "boundary:rect:type": "indexed",
 

--- a/test/view/boundary_circle.js
+++ b/test/view/boundary_circle.js
@@ -7,7 +7,6 @@ function getBaseVariableStore(toExclude) {
   vs.var('boundary:circle:lon', 'lon value');
   vs.var('boundary:circle:radius', 'radius value');
   vs.var('boundary:circle:distance_type', 'distance_type value');
-  vs.var('boundary:circle:optimize_bbox', 'optimize_bbox value');
   vs.var('centroid:field', 'field value');
 
   if (toExclude) {
@@ -54,7 +53,6 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
       geo_distance: {
         distance: { $: 'radius value' },
         distance_type: { $: 'distance_type value' },
-        optimize_bbox: { $: 'optimize_bbox value' },
         'field value': {
           lat: { $: 'lat value' },
           lon: { $: 'lon value' }

--- a/view/boundary_circle.js
+++ b/view/boundary_circle.js
@@ -6,7 +6,6 @@ module.exports = function( vs ){
       !vs.isset('boundary:circle:lon') ||
       !vs.isset('boundary:circle:radius') ||
       !vs.isset('boundary:circle:distance_type') ||
-      !vs.isset('boundary:circle:optimize_bbox') ||
       !vs.isset('centroid:field') ){
     return null;
   }
@@ -16,7 +15,6 @@ module.exports = function( vs ){
     geo_distance: {
       distance: vs.var('boundary:circle:radius'),
       distance_type: vs.var('boundary:circle:distance_type'),
-      optimize_bbox: vs.var('boundary:circle:optimize_bbox')
     }
   };
 


### PR DESCRIPTION
This parameter [was deprecated in Elasticsearch 2.2](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-geo-distance-query.html#_options_4) so it is already having no effect on any of our queries.

