### PR TITLE
Replace deprecated `minimum_number_should_match` field

### DIFF
--- a/layout/AddressesUsingIdsQuery.js
+++ b/layout/AddressesUsingIdsQuery.js
@@ -169,7 +169,7 @@ class AddressesUsingIdsQuery extends Query {
         function_score: {
           query: {
             bool: {
-              minimum_number_should_match: 1,
+              minimum_should_match: 1,
               should: [
                 createStreetShould(vs)
               ]
@@ -216,10 +216,10 @@ class AddressesUsingIdsQuery extends Query {
         return acc;
       }, []);
 
-      // add filter.bool.minimum_number_should_match and filter.bool.should,
+      // add filter.bool.minimum_should_match and filter.bool.should,
       //  creating intermediate objects as it goes
       _.set(base.query.function_score.query.bool, 'filter.bool', {
-        minimum_number_should_match: 1,
+        minimum_should_match: 1,
         should: id_filters
       });
 

--- a/test/fixtures/addressesUsingIdsQuery/housenumber_no_units.json
+++ b/test/fixtures/addressesUsingIdsQuery/housenumber_no_units.json
@@ -3,7 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
-          "minimum_number_should_match": 1,
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/addressesUsingIdsQuery/no_housenumber.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_housenumber.json
@@ -3,7 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
-          "minimum_number_should_match": 1,
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/addressesUsingIdsQuery/no_layers.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_layers.json
@@ -3,7 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
-          "minimum_number_should_match": 1,
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/addressesUsingIdsQuery/no_layers_with_boosts.json
+++ b/test/fixtures/addressesUsingIdsQuery/no_layers_with_boosts.json
@@ -3,7 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
-          "minimum_number_should_match": 1,
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/addressesUsingIdsQuery/unit_no_housenumber.json
+++ b/test/fixtures/addressesUsingIdsQuery/unit_no_housenumber.json
@@ -3,7 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
-          "minimum_number_should_match": 1,
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/addressesUsingIdsQuery/with_filters.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_filters.json
@@ -3,7 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
-          "minimum_number_should_match": 1,
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {

--- a/test/fixtures/addressesUsingIdsQuery/with_layers.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_layers.json
@@ -3,7 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
-          "minimum_number_should_match": 1,
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {
@@ -60,7 +60,7 @@
           ],
           "filter": {
             "bool": {
-              "minimum_number_should_match": 1,
+              "minimum_should_match": 1,
               "should": [
                 {
                   "terms": {

--- a/test/fixtures/addressesUsingIdsQuery/with_layers_and_filters.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_layers_and_filters.json
@@ -3,7 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
-          "minimum_number_should_match": 1,
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {
@@ -60,7 +60,7 @@
           ],
           "filter": {
             "bool": {
-              "minimum_number_should_match": 1,
+              "minimum_should_match": 1,
               "should": [
                 {
                   "terms": {

--- a/test/fixtures/addressesUsingIdsQuery/with_scores.json
+++ b/test/fixtures/addressesUsingIdsQuery/with_scores.json
@@ -3,7 +3,7 @@
     "function_score": {
       "query": {
         "bool": {
-          "minimum_number_should_match": 1,
+          "minimum_should_match": 1,
           "should": [
             {
               "bool": {


### PR DESCRIPTION
This field is deprecated in ES5 and will be removed in ES6. Most of our queries already use the new parameter, `minimum_should_match`, but some use the old one for some reason.

Connects https://github.com/pelias/query/issues/95
Connects https://github.com/pelias/pelias/issues/719