### PR TITLE
feat(deps): Remove check-types in favor of lodash

### DIFF
--- a/lib/Variable.js
+++ b/lib/Variable.js
@@ -14,14 +14,14 @@
  *always* yield true; regardless of the underlying value; because js.
  **/
 
-var check = require('check-types');
+const _ = require('lodash');
 
 function Variable(){
   this.$ = '';
 }
 
 Variable.prototype.set = function( val ){
-  if( !check.nonEmptyString(val) && !check.number(val) && !check.boolean(val) && !check.array(val) && !check.object(val)){
+  if( val === '' || val === null || val === undefined ){
     throw new Error( 'invalid value, value must be valid js Variable' );
   }
   this.$ = val;

--- a/lib/VariableStore.js
+++ b/lib/VariableStore.js
@@ -5,12 +5,13 @@
   note: you may inject your own variables when calling the constructor
 **/
 
-var check = require('check-types'),
-    Variable = require('./Variable');
+const _ = require('lodash');
+
+const Variable = require('./Variable');
 
 function VariableStore( vars ){
   this._vars = {};
-  if( check.assigned( vars ) ){
+  if( !_.isEmpty( vars ) ){
     this.set( vars );
   }
 }
@@ -31,17 +32,19 @@ function VariableStore( vars ){
   vs.var('foo').set('bar');
 **/
 VariableStore.prototype.var = function( key, val ){
-  if( !check.nonEmptyString( key ) ){
+  if( _.isEmpty( key ) || !_.isString( key) )  {
     throw new Error( 'invalid query variable, key must be valid string' );
   }
   // init variable
   if( !this._vars.hasOwnProperty( key ) ){
     this._vars[ key ] = new Variable();
   }
-  // setter
-  if( check.assigned( val ) ){
+
+  // set value if val parameter passed
+  if (val !== undefined) {
     this._vars[ key ].set( val );
   }
+
   // getter
   return this._vars[ key ];
 };
@@ -50,7 +53,7 @@ VariableStore.prototype.var = function( key, val ){
   check if a key has been set (has a value)
 **/
 VariableStore.prototype.isset = function( key ){
-  if( !check.nonEmptyString( key ) ){
+  if( _.isEmpty( key ) || !_.isString( key) )  {
     throw new Error( 'invalid key, must be valid string' );
   }
   // key not set
@@ -65,7 +68,7 @@ VariableStore.prototype.isset = function( key ){
   delete a variable by key
 **/
 VariableStore.prototype.unset = function( key ){
-  if( !check.nonEmptyString( key ) ){
+  if( _.isEmpty( key ) || !_.isString( key) )  {
     throw new Error( 'invalid key, must be valid string' );
   }
   // key not set
@@ -81,7 +84,7 @@ VariableStore.prototype.unset = function( key ){
   import variables from a plain-old-javascript-object
 **/
 VariableStore.prototype.set = function( pojo ){
-  if( !check.object( pojo ) ){
+  if( !_.isPlainObject( pojo ) ){
     throw new Error( 'invalid object' );
   }
   for( var attr in pojo ){

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/pelias/query#readme",
   "dependencies": {
-    "check-types": "^8.0.0",
     "lodash": "^4.17.14"
   },
   "devDependencies": {


### PR DESCRIPTION
Since the creation of this module we have largely settled on lodash as our Javascript helper library of choice. This module was now using both lodash and `check-types`, which seemed excessive and inconsistent.

This change replaces all use of `check-types` with equivalent lodash functionality.

One notable conceptual change is regarding what is valid to store in a `Variable` object used as placeholder values in queries.

Initially, only scalar values were supported: non-empty strings, numbers, and booleans.

However, over time we found it useful to store first arrays and then even objects as variables, meaning its now clearer to enumerate what a `Variable` _doesn't_ support storing: empty strings, `null`, and `undefined`