### PR TITLE
Add minimum_should_match param to ngrams view

### DIFF
--- a/test/view/ngrams.js
+++ b/test/view/ngrams.js
@@ -111,6 +111,30 @@ module.exports.tests.cutoff_frequency = function(test, common) {
   });
 };
 
+module.exports.tests.minimum_should_match = function(test, common) {
+  test('minimum_should_match variable should be presented in query', function(t) {
+    var store = getBaseVariableStore();
+    store.var('ngram:minimum_should_match', 'minimum_should_match value');
+
+    var actual = ngrams(store);
+
+    var expected = {
+      match: {
+        'field value': {
+          analyzer: { $: 'analyzer value' },
+          boost: { $: 'boost value' },
+          query: { $: 'name value' },
+          minimum_should_match: { $: 'minimum_should_match value' }
+        }
+      }
+    };
+
+    t.deepEquals(actual, expected, 'should have returned object with minimum_should_match field');
+    t.end();
+
+  });
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('ngrams ' + name, testFunction);

--- a/view/ngrams.js
+++ b/view/ngrams.js
@@ -27,5 +27,9 @@ module.exports = function( vs ){
     view.match[ vs.var('ngram:field') ].cutoff_frequency = vs.var('ngram:cutoff_frequency');
   }
 
+  if (vs.isset('ngram:minimum_should_match')) {
+    view.match[ vs.var('ngram:field') ].minimum_should_match = vs.var('ngram:minimum_should_match');
+  }
+
   return view;
 };


### PR DESCRIPTION
This parameter is extremely useful for customizing the behavior of queries and how many documents they will match.

See the documentation for all the ways it can be used: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html