### PR TITLE
Actually run category tests

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -16,6 +16,7 @@ var tests = [
   require('./view/boundary_circle.js'),
   require('./view/boundary_country.js'),
   require('./view/boundary_rect.js'),
+  require('./view/categories.js'),
   require('./view/focus.js'),
   require('./view/focus_only_function.js'),
   require('./view/layers.js'),


### PR DESCRIPTION
In the process of making other improvements to the query module, I discovered the tests for the category query view were never run. This is now corrected.