### PR TITLE
chore(tests): Use JSON stringify/parse to render templates

### DIFF
--- a/test/fixtures/fallbackQuery1.json
+++ b/test/fixtures/fallbackQuery1.json
@@ -97,7 +97,7 @@
             {
               "bool": {
                 "_name": "fallback.address",
-                "boost": { "$": 19 },
+                "boost": 19,
                 "must": [
                   {
                     "match_phrase": {
@@ -200,7 +200,7 @@
             {
               "bool": {
                 "_name": "fallback.street",
-                "boost": { "$": 17 },
+                "boost": 17,
                 "must": [
                   {
                     "match_phrase": {
@@ -765,8 +765,8 @@
       "boost_mode": "multiply"
     }
   },
-  "size": { "$": "size value" },
-  "track_scores": { "$": "track_scores value" },
+  "size": "size value",
+  "track_scores": "track_scores value",
   "sort": [
     "_score"
   ]

--- a/test/fixtures/fallbackQuery2.json
+++ b/test/fixtures/fallbackQuery2.json
@@ -8,7 +8,7 @@
             {
               "bool": {
                 "_name": "fallback.address",
-                "boost": { "$": 19 },
+                "boost": 19,
                 "must": [
                   {
                     "match_phrase": {
@@ -104,7 +104,7 @@
             {
               "bool": {
                 "_name": "fallback.street",
-                "boost": { "$": 17 },
+                "boost": 17,
                 "must": [
                   {
                     "match_phrase": {
@@ -669,8 +669,8 @@
       "boost_mode": "multiply"
     }
   },
-  "size": { "$": "size value" },
-  "track_scores": { "$": "track_scores value" },
+  "size": "size value",
+  "track_scores": "track_scores value",
   "sort": [
     "_score"
   ]

--- a/test/fixtures/fallbackQuery_address_with_postcode.json
+++ b/test/fixtures/fallbackQuery_address_with_postcode.json
@@ -8,7 +8,7 @@
             {
               "bool": {
                 "_name": "fallback.address",
-                "boost": { "$": 19 },
+                "boost":19,
                 "must": [
                   {
                     "match_phrase": {
@@ -63,7 +63,7 @@
             {
               "bool": {
                 "_name": "fallback.street",
-                "boost": { "$": 17 },
+                "boost": 17,
                 "must": [
                   {
                     "match_phrase": {
@@ -98,8 +98,8 @@
       "boost_mode": "multiply"
     }
   },
-  "size": { "$": "size value" },
-  "track_scores": { "$": "track_scores value" },
+  "size": "size value",
+  "track_scores": "track_scores value",
   "sort": [
     "_score"
   ]

--- a/test/fixtures/fallbackQuery_neighbourhood_only.json
+++ b/test/fixtures/fallbackQuery_neighbourhood_only.json
@@ -33,8 +33,8 @@
       "boost_mode": "multiply"
     }
   },
-  "size": { "$": "size value" },
-  "track_scores": { "$": "track_scores value" },
+  "size": "size value",
+  "track_scores": "track_scores value",
   "sort": [
     "_score"
   ]

--- a/test/fixtures/fallbackQuery_nothing_set.json
+++ b/test/fixtures/fallbackQuery_nothing_set.json
@@ -13,8 +13,8 @@
       "boost_mode": "multiply"
     }
   },
-  "size": { "$": "size value" },
-  "track_scores": { "$": "track_scores value" },
+  "size": "size value",
+  "track_scores": "track_scores value",
   "sort": [
     "_score"
   ]

--- a/test/fixtures/structuredFallbackQuery/address.json
+++ b/test/fixtures/structuredFallbackQuery/address.json
@@ -8,7 +8,7 @@
             {
               "bool": {
                 "_name": "fallback.address",
-                "boost": { "$": 19 },
+                "boost": 19,
                 "must": [
                   {
                     "match_phrase": {
@@ -111,7 +111,7 @@
             {
               "bool": {
                 "_name": "fallback.street",
-                "boost": { "$": 17 },
+                "boost": 17,
                 "must": [
                   {
                     "match_phrase": {
@@ -676,8 +676,8 @@
       "boost_mode": "multiply"
     }
   },
-  "size": { "$": "size value" },
-  "track_scores": { "$": "track_scores value" },
+  "size": "size value",
+  "track_scores": "track_scores value",
   "sort": [
     "_score"
   ]

--- a/test/fixtures/structuredFallbackQuery/address_with_postcode.json
+++ b/test/fixtures/structuredFallbackQuery/address_with_postcode.json
@@ -8,7 +8,7 @@
             {
               "bool": {
                 "_name": "fallback.address",
-                "boost": { "$": 19 },
+                "boost": 19,
                 "must": [
                   {
                     "match_phrase": {
@@ -44,7 +44,7 @@
             {
               "bool": {
                 "_name": "fallback.street",
-                "boost": { "$": 17 },
+                "boost": 17,
                 "must": [
                   {
                     "match_phrase": {
@@ -98,8 +98,8 @@
       "boost_mode": "multiply"
     }
   },
-  "size": { "$": "size value" },
-  "track_scores": { "$": "track_scores value" },
+  "size": "size value",
+  "track_scores": "track_scores value",
   "sort": [
     "_score"
   ]

--- a/test/fixtures/structuredFallbackQuery/housenumber.json
+++ b/test/fixtures/structuredFallbackQuery/housenumber.json
@@ -8,7 +8,7 @@
             {
               "bool": {
                 "_name": "fallback.housenumber",
-                "boost": { "$": 19 },
+                "boost": 19,
                 "must": [
                   {
                     "match_phrase": {
@@ -35,8 +35,8 @@
       "boost_mode": "multiply"
     }
   },
-  "size": { "$": "size value" },
-  "track_scores": { "$": "track_scores value" },
+  "size": "size value",
+  "track_scores": "track_scores value",
   "sort": [
     "_score"
   ]

--- a/test/fixtures/structuredFallbackQuery/locality_as_borough.json
+++ b/test/fixtures/structuredFallbackQuery/locality_as_borough.json
@@ -160,8 +160,8 @@
       "boost_mode": "multiply"
     }
   },
-  "size": { "$": "size value" },
-  "track_scores": { "$": "track_scores value" },
+  "size": "size value",
+  "track_scores": "track_scores value",
   "sort": [
     "_score"
   ]

--- a/test/fixtures/structuredFallbackQuery/query.json
+++ b/test/fixtures/structuredFallbackQuery/query.json
@@ -98,7 +98,7 @@
             {
               "bool": {
                 "_name": "fallback.address",
-                "boost": { "$": 19 },
+                "boost": 19,
                 "must": [
                   {
                     "match_phrase": {
@@ -194,7 +194,7 @@
             {
               "bool": {
                 "_name": "fallback.street",
-                "boost": { "$": 17 },
+                "boost": 17,
                 "must": [
                   {
                     "match_phrase": {
@@ -759,8 +759,8 @@
       "boost_mode": "multiply"
     }
   },
-  "size": { "$": "size value" },
-  "track_scores": { "$": "track_scores value" },
+  "size": "size value",
+  "track_scores": "track_scores value",
   "sort": [
     "_score"
   ]

--- a/test/layout/FallbackQuery.js
+++ b/test/layout/FallbackQuery.js
@@ -12,7 +12,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('size', 'size value');
     vs.var('track_scores', 'track_scores value');
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/fallbackQuery_nothing_set.json');
 
     t.deepEquals(actual, expected);
@@ -28,7 +28,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('track_scores', 'track_scores value');
     vs.var('input:neighbourhood', 'neighbourhood value');
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/fallbackQuery_neighbourhood_only.json');
 
     t.deepEquals(actual, expected);
@@ -55,7 +55,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('boost:address', 19);
     vs.var('boost:street', 17);
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/fallbackQuery1.json');
 
     t.deepEquals(actual, expected);
@@ -80,7 +80,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('boost:address', 19);
     vs.var('boost:street', 17);
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/fallbackQuery2.json');
 
     t.deepEquals(actual, expected);
@@ -102,7 +102,7 @@ module.exports.tests.base_render = function(test, common) {
 
     var fs = require('fs');
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/fallbackQuery_address_with_postcode.json');
 
     t.deepEquals(actual, expected);
@@ -122,7 +122,7 @@ module.exports.tests.boosts = function(test, common) {
     vs.var('input:housenumber', 'house number value');
     vs.var('input:street', 'street value');
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
 
     t.false(actual.query.function_score.query.bool.should[0].bool.hasOwnProperty('boost'));
     t.false(actual.query.function_score.query.bool.should[1].bool.hasOwnProperty('boost'));

--- a/test/layout/StructuredFallbackQuery.js
+++ b/test/layout/StructuredFallbackQuery.js
@@ -12,7 +12,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('size', 'size value');
     vs.var('track_scores', 'track_scores value');
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/fallbackQuery_nothing_set.json');
 
     t.deepEquals(actual, expected);
@@ -28,7 +28,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('track_scores', 'track_scores value');
     vs.var('input:neighbourhood', 'neighbourhood value');
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/fallbackQuery_neighbourhood_only.json');
 
     t.deepEquals(actual, expected);
@@ -54,7 +54,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('boost:address', 19);
     vs.var('boost:street', 17);
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/structuredFallbackQuery/address.json');
 
     t.deepEquals(actual, expected);
@@ -80,7 +80,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('boost:address', 19);
     vs.var('boost:street', 17);
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/structuredFallbackQuery/query.json');
 
     t.deepEquals(actual, expected);
@@ -97,7 +97,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('track_scores', 'track_scores value');
     vs.var('boost:address', 19);
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/structuredFallbackQuery/housenumber.json');
 
     t.deepEquals(actual, expected);
@@ -116,7 +116,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('boost:address', 19);
     vs.var('boost:street', 17);
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/structuredFallbackQuery/address_with_postcode.json');
 
     t.deepEquals(actual, expected);
@@ -133,7 +133,7 @@ module.exports.tests.base_render = function(test, common) {
     vs.var('input:locality', 'locality value');
     vs.var('input:region', 'region value');
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var expected = require('../fixtures/structuredFallbackQuery/locality_as_borough.json');
 
     t.deepEquals(actual, expected);
@@ -153,7 +153,7 @@ module.exports.tests.boosts = function(test, common) {
     vs.var('input:housenumber', 'house number value');
     vs.var('input:street', 'street value');
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
 
     t.false(actual.query.function_score.query.bool.should[0].bool.hasOwnProperty('boost'));
     t.false(actual.query.function_score.query.bool.should[1].bool.hasOwnProperty('boost'));
@@ -192,7 +192,7 @@ module.exports.tests.scores = function(test, common) {
     vs.var('size', 'size value');
     vs.var('track_scores', 'track_scores value');
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
     var actual_scoring_functions = actual.query.function_score.functions;
 
     var expected_scoring_functions = [
@@ -234,7 +234,7 @@ module.exports.tests.filter = function(test, common) {
     vs.var('size', 'size value');
     vs.var('track_scores', 'track_scores value');
 
-    var actual = query.render(vs);
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
 
     var expected_filter = [
       { 'filter field 1': 'filter value 1'},


### PR DESCRIPTION
This avoids having to encode the internal storage format of VariableStore in the fixtures