### PR TITLE
feat(match_phrase): Use match_phrase lib

### DIFF
--- a/layout/AddressesUsingIdsQuery.js
+++ b/layout/AddressesUsingIdsQuery.js
@@ -1,27 +1,14 @@
-'use strict';
-
 const _ = require('lodash');
 const Query = require('./Query');
+const match_phrase = require('../lib/leaf/match_phrase');
 
 function createAddressShould(vs) {
   const should = {
     bool: {
       _name: 'fallback.address',
       must: [
-        {
-          match_phrase: {
-            'address_parts.number': {
-              query: vs.var('input:housenumber')
-            }
-          }
-        },
-        {
-          match_phrase: {
-            'address_parts.street': {
-              query: vs.var('input:street')
-            }
-          }
-        }
+        match_phrase('address_parts.number', vs.var('input:housenumber')),
+        match_phrase('address_parts.street', vs.var('input:street'))
       ],
       filter: {
         term: {
@@ -43,27 +30,9 @@ function createUnitAndAddressShould(vs) {
     bool: {
       _name: 'fallback.address',
       must: [
-        {
-          match_phrase: {
-            'address_parts.unit': {
-              query: vs.var('input:unit')
-            }
-          }
-        },
-        {
-          match_phrase: {
-            'address_parts.number': {
-              query: vs.var('input:housenumber')
-            }
-          }
-        },
-        {
-          match_phrase: {
-            'address_parts.street': {
-              query: vs.var('input:street')
-            }
-          }
-        }
+        match_phrase('address_parts.unit', vs.var('input:unit')),
+        match_phrase('address_parts.number', vs.var('input:housenumber')),
+        match_phrase('address_parts.street', vs.var('input:street'))
       ],
       filter: {
         term: {
@@ -85,27 +54,9 @@ function createPostcodeAndAddressShould(vs) {
     bool: {
       _name: 'fallback.address',
       must: [
-        {
-          match_phrase: {
-            'address_parts.zip': {
-              query: vs.var('input:postcode')
-            }
-          }
-        },
-        {
-          match_phrase: {
-            'address_parts.number': {
-              query: vs.var('input:housenumber')
-            }
-          }
-        },
-        {
-          match_phrase: {
-            'address_parts.street': {
-              query: vs.var('input:street')
-            }
-          }
-        }
+        match_phrase('address_parts.zip', vs.var('input:postcode')),
+        match_phrase('address_parts.number', vs.var('input:housenumber')),
+        match_phrase('address_parts.street', vs.var('input:street'))
       ],
       filter: {
         term: {
@@ -127,13 +78,7 @@ function createStreetShould(vs) {
     bool: {
       _name: 'fallback.street',
       must: [
-        {
-          match_phrase: {
-            'address_parts.street': {
-              query: vs.var('input:street')
-            }
-          }
-        }
+        match_phrase('address_parts.street', vs.var('input:street'))
       ],
       filter: {
         term: {

--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -29,6 +29,8 @@
 var _ = require('lodash');
 var baseQuery = require('./baseQuery');
 
+const match_phrase = require('../lib/leaf/match_phrase');
+
 function Layout(){
   this._score = [];
   this._filter = [];
@@ -110,13 +112,9 @@ function addSecondary(value, fields) {
 function addSecPostCode(vs, o) {
   // add postcode if specified
   if (vs.isset('input:postcode')) {
-    o.bool.should.push({
-      match_phrase: {
-        'address_parts.zip': {
-          query: vs.var('input:postcode').toString()
-        }
-      }
-    });
+    o.bool.should.push(
+      match_phrase('address_parts.zip', vs.var('input:postcode'))
+    );
   }
 }
 
@@ -233,27 +231,9 @@ function addUnitAndHouseNumberAndStreet(vs) {
     bool: {
       _name: 'fallback.address',
       must: [
-        {
-          match_phrase: {
-            'address_parts.unit': {
-              query: vs.var('input:unit').toString()
-            }
-          }
-        },
-        {
-          match_phrase: {
-            'address_parts.number': {
-              query: vs.var('input:housenumber').toString()
-            }
-          }
-        },
-        {
-          match_phrase: {
-            'address_parts.street': {
-              query: vs.var('input:street').toString()
-            }
-          }
-        }
+        match_phrase('address_parts.unit', vs.var('input:unit')),
+        match_phrase('address_parts.number', vs.var('input:housenumber')),
+        match_phrase('address_parts.street', vs.var('input:street'))
       ],
       should: [],
       filter: {
@@ -277,7 +257,6 @@ function addUnitAndHouseNumberAndStreet(vs) {
   addSecCountry(vs, o);
 
   return o;
-
 }
 
 function addHouseNumberAndStreet(vs) {
@@ -285,20 +264,8 @@ function addHouseNumberAndStreet(vs) {
     bool: {
       _name: 'fallback.address',
       must: [
-        {
-          match_phrase: {
-            'address_parts.number': {
-              query: vs.var('input:housenumber').toString()
-            }
-          }
-        },
-        {
-          match_phrase: {
-            'address_parts.street': {
-              query: vs.var('input:street').toString()
-            }
-          }
-        }
+        match_phrase('address_parts.number', vs.var('input:housenumber')),
+        match_phrase('address_parts.street', vs.var('input:street'))
       ],
       should: [],
       filter: {
@@ -330,13 +297,7 @@ function addStreet(vs) {
     bool: {
       _name: 'fallback.street',
       must: [
-        {
-          match_phrase: {
-            'address_parts.street': {
-              query: vs.var('input:street').toString()
-            }
-          }
-        }
+        match_phrase('address_parts.street', vs.var('input:street'))
       ],
       should: [],
       filter: {

--- a/layout/StructuredFallbackQuery.js
+++ b/layout/StructuredFallbackQuery.js
@@ -8,6 +8,8 @@
 var _ = require('lodash');
 var baseQuery = require('./baseQuery');
 
+const match_phrase = require('../lib/leaf/match_phrase');
+
 function Layout(){
   this._score = [];
   this._filter = [];
@@ -68,13 +70,9 @@ function addSecondary(value, fields) {
 function addSecPostCode(vs, o) {
   // add postcode if specified
   if (vs.isset('input:postcode')) {
-    o.bool.should.push({
-      match_phrase: {
-        'address_parts.zip': {
-          query: vs.var('input:postcode').toString()
-        }
-      }
-    });
+    o.bool.should.push(
+      match_phrase('address_parts.zip', vs.var('input:postcode'))
+    );
   }
 }
 
@@ -192,27 +190,9 @@ function addUnitAndHouseNumberAndStreet(vs) {
     bool: {
       _name: 'fallback.address',
       must: [
-        {
-          match_phrase: {
-            'address_parts.unit': {
-              query: vs.var('input:unit').toString()
-            }
-          }
-        },
-        {
-          match_phrase: {
-            'address_parts.number': {
-              query: vs.var('input:housenumber').toString()
-            }
-          }
-        },
-        {
-          match_phrase: {
-            'address_parts.street': {
-              query: vs.var('input:street').toString()
-            }
-          }
-        }
+        match_phrase('address_parts.unit', vs.var('input:unit')),
+        match_phrase('address_parts.number', vs.var('input:housenumber')),
+        match_phrase('address_parts.street', vs.var('input:street'))
       ],
       should: [],
       filter: {
@@ -281,20 +261,8 @@ function addHouseNumberAndStreet(vs) {
     bool: {
       _name: 'fallback.address',
       must: [
-        {
-          match_phrase: {
-            'address_parts.number': {
-              query: vs.var('input:housenumber').toString()
-            }
-          }
-        },
-        {
-          match_phrase: {
-            'address_parts.street': {
-              query: vs.var('input:street').toString()
-            }
-          }
-        }
+        match_phrase('address_parts.number', vs.var('input:housenumber')),
+        match_phrase('address_parts.street', vs.var('input:street'))
       ],
       should: [],
       filter: {
@@ -326,13 +294,7 @@ function addStreet(vs) {
     bool: {
       _name: 'fallback.street',
       must: [
-        {
-          match_phrase: {
-            'address_parts.street': {
-              query: vs.var('input:street').toString()
-            }
-          }
-        }
+        match_phrase('address_parts.street', vs.var('input:street'))
       ],
       should: [],
       filter: {


### PR DESCRIPTION
This uses the match_phrase helper function defined in https://github.com/pelias/query/pull/109 to cut down on duplication when creating `match_phrase` queries.

Since the structure of the `match_phrase` query is defined in one place, it makes the resulting view code a bit more concise.

It will also make optional parameter handling easier and more consistent.