### PR TITLE
fix(lib): Ensure match and match_phrase handle empty Variables

### DIFF
--- a/lib/leaf/match.js
+++ b/lib/leaf/match.js
@@ -25,7 +25,7 @@ module.exports = function( property, value, params) {
   };
 
   optional_params.forEach(function(param) {
-    if (params && params[param]) {
+    if (params && params[param] && params[param].toString() !== '') {
       query.match[property][param] = params[param];
     }
   });

--- a/lib/leaf/match_phrase.js
+++ b/lib/leaf/match_phrase.js
@@ -14,7 +14,7 @@ module.exports = function( property, value, params ) {
   const optional_params = ['boost', 'slop', 'analyzer'];
 
   optional_params.forEach(function(param) {
-    if (params && params[param]) {
+    if (params && params[param] && params[param].toString() !== '') {
       query.match_phrase[property][param] = params[param];
     }
   });

--- a/test/lib/leaf/match.js
+++ b/test/lib/leaf/match.js
@@ -1,4 +1,5 @@
 const match = require('../../../lib/leaf/match');
+const Variable = require('../../../lib/Variable');
 
 module.exports.tests = {};
 
@@ -125,6 +126,36 @@ module.exports.tests.match = function(test, common) {
     };
 
     t.deepEqual(query, expected, 'valid match query with analyzer');
+    t.end();
+  });
+
+  test('match query does not allow empty string as optional param value', function(t) {
+    const query = match('property', 'value', { analyzer: ''});
+
+    const expected = {
+      match: {
+        property: {
+          query: 'value'
+        }
+      }
+    };
+
+    t.deepEqual(query, expected, 'valid match query with out empty string value');
+    t.end();
+  });
+
+  test('match query does not allow empty Variable as optional param value', function(t) {
+    const query = match('property', 'value', { analyzer: new Variable() });
+
+    const expected = {
+      match: {
+        property: {
+          query: 'value'
+        }
+      }
+    };
+
+    t.deepEqual(query, expected, 'valid match query with out empty string value');
     t.end();
   });
 };

--- a/test/lib/leaf/match_phrase.js
+++ b/test/lib/leaf/match_phrase.js
@@ -1,4 +1,5 @@
 const match_phrase = require('../../../lib/leaf/match_phrase');
+const Variable = require('../../../lib/Variable');
 
 module.exports.tests = {};
 
@@ -77,6 +78,36 @@ module.exports.tests.match_phrase = function(test, common) {
     };
 
     t.deepEqual(query, expected, 'valid match_phrase query with analyzer');
+    t.end();
+  });
+
+  test('match_phrase query does not allow empty string as optional param value', function(t) {
+    const query = match_phrase('property', 'value', { slop: '' });
+
+    const expected = {
+      match_phrase: {
+        property: {
+          query: 'value'
+        }
+      }
+    };
+
+    t.deepEqual(query, expected, 'valid match_phrase query without empty string value');
+    t.end();
+  });
+
+  test('match_phrase query does not allow empty Variable as optional param value', function(t) {
+    const query = match_phrase('property', 'value', { analyzer: new Variable() });
+
+    const expected = {
+      match_phrase: {
+        property: {
+          query: 'value'
+        }
+      }
+    };
+
+    t.deepEqual(query, expected, 'valid match_phrase query with out empty string value');
     t.end();
   });
 };


### PR DESCRIPTION
We want the match and match_phrase helper functions to gracefully handle the case where a variable has no value, which internally is an empty string.

This requires doing an explicit comparison to ensure that optional parameters are not set unless the variable is actually defined.
