### PR TITLE
feat(fallback queries): Support slop parameter on street queries

### DIFF
--- a/layout/AddressesUsingIdsQuery.js
+++ b/layout/AddressesUsingIdsQuery.js
@@ -8,7 +8,7 @@ function createAddressShould(vs) {
       _name: 'fallback.address',
       must: [
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'))
+        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
       ],
       filter: {
         term: {
@@ -32,7 +32,7 @@ function createUnitAndAddressShould(vs) {
       must: [
         match_phrase('address_parts.unit', vs.var('input:unit')),
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'))
+        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
       ],
       filter: {
         term: {
@@ -56,7 +56,7 @@ function createPostcodeAndAddressShould(vs) {
       must: [
         match_phrase('address_parts.zip', vs.var('input:postcode')),
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'))
+        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
       ],
       filter: {
         term: {
@@ -78,7 +78,7 @@ function createStreetShould(vs) {
     bool: {
       _name: 'fallback.street',
       must: [
-        match_phrase('address_parts.street', vs.var('input:street'))
+        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
       ],
       filter: {
         term: {

--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -233,7 +233,7 @@ function addUnitAndHouseNumberAndStreet(vs) {
       must: [
         match_phrase('address_parts.unit', vs.var('input:unit')),
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'))
+        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
       ],
       should: [],
       filter: {
@@ -265,7 +265,7 @@ function addHouseNumberAndStreet(vs) {
       _name: 'fallback.address',
       must: [
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'))
+        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
       ],
       should: [],
       filter: {
@@ -297,7 +297,7 @@ function addStreet(vs) {
     bool: {
       _name: 'fallback.street',
       must: [
-        match_phrase('address_parts.street', vs.var('input:street'))
+        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
       ],
       should: [],
       filter: {

--- a/layout/StructuredFallbackQuery.js
+++ b/layout/StructuredFallbackQuery.js
@@ -192,7 +192,7 @@ function addUnitAndHouseNumberAndStreet(vs) {
       must: [
         match_phrase('address_parts.unit', vs.var('input:unit')),
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'))
+        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
       ],
       should: [],
       filter: {
@@ -262,7 +262,7 @@ function addHouseNumberAndStreet(vs) {
       _name: 'fallback.address',
       must: [
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'))
+        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
       ],
       should: [],
       filter: {
@@ -294,7 +294,7 @@ function addStreet(vs) {
     bool: {
       _name: 'fallback.street',
       must: [
-        match_phrase('address_parts.street', vs.var('input:street'))
+        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
       ],
       should: [],
       filter: {


### PR DESCRIPTION
This change builds on the previous series of PRs (https://github.com/pelias/query/pull/112, and https://github.com/pelias/query/pull/111) to support the `slop` parameter on the `match_phrase` queries responsible for handling street addresses.

Unlike #101 this method does not set the `slop` parameter unconditionally, and no changes to queries will result unless the slop parameter is configured such as with https://github.com/pelias/api/pull/1322.