### PR TITLE
use cross_fields type for multi_match

### DIFF
--- a/test/view/admin_multi_match.js
+++ b/test/view/admin_multi_match.js
@@ -92,7 +92,8 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           'property2_field value^property2_boost value'
         ],
         'query': { $: 'property1 value' },
-        'analyzer': 'analyzer value'
+        'analyzer': 'analyzer value',
+        'type': { $: 'cross_fields' }
       }
     };
 
@@ -117,7 +118,8 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           'property1_field value^1'
         ],
         'query': { $: 'property1 value' },
-        'analyzer': 'analyzer value'
+        'analyzer': 'analyzer value',
+        'type': { $: 'cross_fields' }
       }
     };
 

--- a/view/admin_multi_match.js
+++ b/view/admin_multi_match.js
@@ -41,6 +41,11 @@ module.exports = function( admin_properties, analyzer ){
     // TODO: handle the case where not all admin area input values are the same
     var queryVar = 'input:' + valid_admin_properties[0];
 
+    // admin multi-matching should always use the 'cross_fields' matching type
+    // this is to ensure that scoring is not only based on the best matching field.
+    // see: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#multi-match-types
+    vs.var('multi_match:type', 'cross_fields');
+
     // send the parameters to the standard multi_match view
     var view = multi_match(vs, fields_with_boosts, analyzer, queryVar);
 

--- a/view/admin_multi_match.js
+++ b/view/admin_multi_match.js
@@ -46,6 +46,10 @@ module.exports = function( admin_properties, analyzer ){
     // see: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#multi-match-types
     vs.var('multi_match:type', 'cross_fields');
 
+    // disable cutoff_frequency as most of these admin  terms are very common
+    // and we would still like them to match and score appropriately.
+    vs.unset('multi_match:cutoff_frequency');
+
     // send the parameters to the standard multi_match view
     var view = multi_match(vs, fields_with_boosts, analyzer, queryVar);
 


### PR DESCRIPTION
I noticed a bug today where which causes `admin_multi_match` queries to score results incorrectly for multi-term admin queries.

I'll attach a simple test-case below, prior to this PR we were using the default `best_fields` type which would essentially ignore the "Eureka" part of the query, meaning that the results were returned in the wrong order:

```
1) Target, California, MD, USA
2) Target, Eureka, CA, USA
```

By changing this to `cross_fields` we are able to use the combined score across all fields, which in-turn scores the query correctly, returning the "Eureka" result first.

```js
{
    "query": {
        "bool": {
            "must": [
                {
                    "match": {
                        "name.default": {
                            "analyzer": "peliasQuery",
                            "query": "Target"
                        }
                    }
                },
                {
                    "multi_match": {
                        "fields": [
                            "parent.country^1",
                            "parent.region^1",
                            "parent.county^1",
                            "parent.localadmin^1",
                            "parent.locality^1",
                            "parent.borough^1",
                            "parent.neighbourhood^1",
                            "parent.region_a^1"
                        ],
                        "type": "best_fields",
                        "query": "Eureka California",
                        "analyzer": "peliasAdmin",
                        "cutoff_frequency": 0.01
                    }
                }
            ]
        }
    },
    "size": 20
}
```