### PR TITLE
chore(TravisCI): Remove deprecated `matrix` config section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ node_js:
   - 8
   - 10
   - 12
-matrix:
-  fast_finish: true
 script: npm run travis
 before_install:
   - npm i -g npm


### PR DESCRIPTION
This config entry is deprecated, and has now started overwriting the `jobs` section, causing build issues.

Connects pelias/pelias#850