### PR TITLE
Allow specifying analyzer for `address_parts.street` field

### DIFF
--- a/layout/AddressesUsingIdsQuery.js
+++ b/layout/AddressesUsingIdsQuery.js
@@ -8,7 +8,10 @@ function createAddressShould(vs) {
       _name: 'fallback.address',
       must: [
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
+        match_phrase('address_parts.street', vs.var('input:street'), {
+          slop: vs.var('address:street:slop'),
+          analyzer: vs.var('address:street:analyzer')
+        })
       ],
       filter: {
         term: {
@@ -32,7 +35,10 @@ function createUnitAndAddressShould(vs) {
       must: [
         match_phrase('address_parts.unit', vs.var('input:unit')),
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
+        match_phrase('address_parts.street', vs.var('input:street'), {
+          slop: vs.var('address:street:slop'),
+          analyzer: vs.var('address:street:analyzer')
+        })
       ],
       filter: {
         term: {
@@ -56,7 +62,10 @@ function createPostcodeAndAddressShould(vs) {
       must: [
         match_phrase('address_parts.zip', vs.var('input:postcode')),
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
+        match_phrase('address_parts.street', vs.var('input:street'), {
+          slop: vs.var('address:street:slop'),
+          analyzer: vs.var('address:street:analyzer')
+        })
       ],
       filter: {
         term: {
@@ -78,7 +87,10 @@ function createStreetShould(vs) {
     bool: {
       _name: 'fallback.street',
       must: [
-        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
+        match_phrase('address_parts.street', vs.var('input:street'), {
+          slop: vs.var('address:street:slop'),
+          analyzer: vs.var('address:street:analyzer')
+        })
       ],
       filter: {
         term: {

--- a/layout/FallbackQuery.js
+++ b/layout/FallbackQuery.js
@@ -233,7 +233,10 @@ function addUnitAndHouseNumberAndStreet(vs) {
       must: [
         match_phrase('address_parts.unit', vs.var('input:unit')),
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
+        match_phrase('address_parts.street', vs.var('input:street'), {
+          slop: vs.var('address:street:slop'),
+          analyzer: vs.var('address:street:analyzer')
+        })
       ],
       should: [],
       filter: {
@@ -265,7 +268,10 @@ function addHouseNumberAndStreet(vs) {
       _name: 'fallback.address',
       must: [
         match_phrase('address_parts.number', vs.var('input:housenumber')),
-        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
+        match_phrase('address_parts.street', vs.var('input:street'), {
+          slop: vs.var('address:street:slop'),
+          analyzer: vs.var('address:street:analyzer')
+        })
       ],
       should: [],
       filter: {
@@ -297,7 +303,10 @@ function addStreet(vs) {
     bool: {
       _name: 'fallback.street',
       must: [
-        match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
+        match_phrase('address_parts.street', vs.var('input:street'), {
+          slop: vs.var('address:street:slop'),
+          analyzer: vs.var('address:street:analyzer')
+        })
       ],
       should: [],
       filter: {


### PR DESCRIPTION
Both the FallbackQuery and AddressUsingIDsQuery do not allow specifying an `analyzer` value at query-time for most fields.

This PR adds the ability to do so for queries against the `address_parts.street` field. We may find this useful if we want to be able to change analyzers easily with API code.