### PR TITLE
Add support to dependencies

### DIFF
--- a/test/view/boundary_country.js
+++ b/test/view/boundary_country.js
@@ -5,7 +5,6 @@ function getBaseVariableStore(toExclude) {
   var vs = new VariableStore();
   vs.var('boundary:country', 'boundary_country');
   vs.var('admin:country_a:analyzer', 'country_a_analyzer');
-  vs.var('admin:country_a:field', 'country_a_field');
 
   if (toExclude) {
     vs.unset(toExclude);
@@ -48,14 +47,13 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
     var actual = boundary_country(vs);
 
     var expected = {
-      match: {
-        country_a_field: {
-          analyzer: {
-            $: 'country_a_analyzer'
-          },
-          query: {
-            $: 'boundary_country'
-          }
+      multi_match: {
+        fields: [ 'parent.country_a', 'parent.dependency_a' ],
+        analyzer: {
+          $: 'country_a_analyzer'
+        },
+        query: {
+          $: 'boundary_country'
         }
       }
     };

--- a/view/boundary_country.js
+++ b/view/boundary_country.js
@@ -3,16 +3,16 @@ module.exports = function( vs ){
 
   // validate required params
   if( !vs.isset('boundary:country') ||
-      !vs.isset('admin:country_a:analyzer') ||
-      !vs.isset('admin:country_a:field') ){
+      !vs.isset('admin:country_a:analyzer') ){
     return null;
   }
 
   // base view
-  var view = { 'match': {} };
+  var view = { };
 
   // match query
-  view.match[ vs.var('admin:country_a:field') ] = {
+  view.multi_match = {
+    fields: [ 'parent.country_a', 'parent.dependency_a' ],
     analyzer: vs.var('admin:country_a:analyzer'),
     query: vs.var('boundary:country')
   };


### PR DESCRIPTION
I noticed that dependencies were often seen as countries, but it is not possible to use the `boundary.country` parameter to filter searches for documents that are located in dependencies.

Now the view `boundary_country` uses a `multi_match` query to match both `country_a` and `dependency_a`.

This code is fully backward compatible (needs API changes).