### PR TITLE
Remove cutoff_frequency, deprecated in es7.3.0, forbidden in es8

### DIFF
--- a/lib/leaf/match.js
+++ b/lib/leaf/match.js
@@ -2,7 +2,6 @@ const optional_params = [
   'boost',
   'operator',
   'analyzer',
-  'cutoff_frequency',
   'fuzziness',
   'max_expansions',
   'prefix_length',

--- a/lib/leaf/multi_match.js
+++ b/lib/leaf/multi_match.js
@@ -1,12 +1,12 @@
 const MATCH_PARAMS = [
   'tie_breaker', 'analyzer', 'boost', 'operator', 'minimum_should_match', 'fuzziness',
-  'lenient', 'prefix_length', 'max_expansions', 'rewrite', 'zero_terms_query', 'cutoff_frequency'
+  'lenient', 'prefix_length', 'max_expansions', 'rewrite', 'zero_terms_query'
 ];
 const PHRASE_PARAMS = ['analyzer', 'boost', 'lenient', 'slop', 'zero_terms_query'];
 const OPTIONAL_PARAMS = {
   'best_fields': MATCH_PARAMS,
   'most_fields': MATCH_PARAMS,
-  'cross_fields': ['analyzer', 'boost', 'operator', 'minimum_should_match', 'lenient', 'zero_terms_query', 'cutoff_frequency'],
+  'cross_fields': ['analyzer', 'boost', 'operator', 'minimum_should_match', 'lenient', 'zero_terms_query'],
   'phrase': PHRASE_PARAMS,
   'phrase_prefix': PHRASE_PARAMS.concat('max_expansions')
 };

--- a/test/lib/leaf/match.js
+++ b/test/lib/leaf/match.js
@@ -49,22 +49,6 @@ module.exports.tests.match = function(test, common) {
     t.end();
   });
 
-  test('match query can handle optional cutoff_frequency parameter', function(t) {
-    const query = match('property', 'value', { cutoff_frequency: 0.01});
-
-    const expected = {
-      match: {
-        property: {
-          query: 'value',
-          cutoff_frequency: 0.01
-        }
-      }
-    };
-
-    t.deepEqual(query, expected, 'valid match query with cutoff_frequency');
-    t.end();
-  });
-
   test('match query can handle optional minimum_should_match parameter', function(t) {
     const query = match('property', 'value', { minimum_should_match: '25%'});
 

--- a/test/view/address.js
+++ b/test/view/address.js
@@ -34,7 +34,6 @@ module.exports.tests.no_property = function(test, common) {
     vs.var('address::analyzer', 'analyzer value');
     vs.var('address::field', 'field value');
     vs.var('address::boost', 'boost value');
-    vs.var('address::cutoff_frequency', 'cutoff_frequency value');
 
     var undefinedPropertyAddress = require('../../view/address')('');
     var actual = undefinedPropertyAddress(vs);
@@ -50,7 +49,6 @@ module.exports.tests.no_property = function(test, common) {
     vs.var('address:0:analyzer', 'analyzer value');
     vs.var('address:0:field', 'field value');
     vs.var('address:0:boost', 'boost value');
-    vs.var('address:0:cutoff_frequency', 'cutoff_frequency value');
 
     var numericPropertyAddress = require('../../view/address')(0);
     var actual = numericPropertyAddress(vs);
@@ -66,7 +64,6 @@ module.exports.tests.no_property = function(test, common) {
     vs.var('address:false:analyzer', 'analyzer value');
     vs.var('address:false:field', 'field value');
     vs.var('address:false:boost', 'boost value');
-    vs.var('address:false:cutoff_frequency', 'cutoff_frequency value');
 
     var falseyPropertyAddress = require('../../view/address')(false);
     var actual = falseyPropertyAddress(vs);
@@ -100,7 +97,6 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
     vs.var('address:asdf:analyzer', 'analyzer value');
     vs.var('address:asdf:field', 'field value');
     vs.var('address:asdf:boost', 'boost value');
-    vs.var('address:asdf:cutoff_frequency', 'cutoff_frequency value');
 
     var actual = address(vs);
 
@@ -112,9 +108,6 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
           },
           boost: {
             $: 'boost value'
-          },
-          cutoff_frequency: {
-            $: 'cutoff_frequency value'
           },
           query: {
             $: 'input value'

--- a/test/view/admin.js
+++ b/test/view/admin.js
@@ -88,39 +88,6 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
   });
 };
 
-module.exports.tests.cutoff_frequency = function(test, common) {
-  test('cutoff_frequency value used if provided', function(t) {
-    var vs = getBaseVariableStore();
-
-    vs.var('admin:asdf:cutoff_frequency', 'cutoff_frequency value');
-
-    var actual = admin(vs);
-
-    var expected = {
-      match: {
-        'field value': {
-          analyzer: {
-            $: 'analyzer value'
-          },
-          boost: {
-            $: 'boost value'
-          },
-          cutoff_frequency: {
-            $: 'cutoff_frequency value'
-          },
-          query: {
-            $: 'input value'
-          }
-        }
-      }
-    };
-
-    t.deepEquals(actual, expected, 'should have returned object');
-    t.end();
-
-  });
-};
-
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('admin ' + name, testFunction);

--- a/test/view/leaf/match.js
+++ b/test/view/leaf/match.js
@@ -32,7 +32,6 @@ module.exports.tests.base_usage = function(test, common) {
     vs.var('match:example2:input', 'input value');
     vs.var('match:example2:field', 'field value');
     vs.var('match:example2:fuzziness', 2);
-    vs.var('match:example2:cutoff_frequency', 0.01);
     vs.var('match:example2:analyzer', 'customAnalyzer');
 
     const view = match('example2')(vs);
@@ -44,7 +43,6 @@ module.exports.tests.base_usage = function(test, common) {
         ['field value']: {
           query: 'input value',
           fuzziness: 2,
-          cutoff_frequency: 0.01,
           analyzer: 'customAnalyzer'
         }
       }

--- a/test/view/leaf/multi_match.js
+++ b/test/view/leaf/multi_match.js
@@ -30,7 +30,6 @@ module.exports.tests.base_usage = function(test, common) {
     const vs = new VariableStore();
     vs.var('multi_match:example2:input', 'input value');
     vs.var('multi_match:example2:fields', ['fields', 'values']);
-    vs.var('multi_match:example2:cutoff_frequency', 0.001);
     vs.var('multi_match:example2:analyzer', 'customAnalyzer');
 
     const view = multi_match('example2')(vs);
@@ -43,7 +42,6 @@ module.exports.tests.base_usage = function(test, common) {
         fields: ['fields', 'values'],
         query: 'input value',
         analyzer: 'customAnalyzer',
-        cutoff_frequency: 0.001
       }
     };
 
@@ -56,7 +54,6 @@ module.exports.tests.base_usage = function(test, common) {
     vs.var('multi_match:example2:input', 'input value');
     vs.var('multi_match:example2:type', 'phrase');
     vs.var('multi_match:example2:fields', ['fields', 'values']);
-    vs.var('multi_match:example2:cutoff_frequency', 0.001); // this will be ignored because it's a phrase type
     vs.var('multi_match:example2:analyzer', 'customAnalyzer');
     vs.var('multi_match:example2:slop', 3);
 

--- a/test/view/ngrams.js
+++ b/test/view/ngrams.js
@@ -87,30 +87,6 @@ module.exports.tests.fuzziness_variable = function(test, common) {
   });
 };
 
-module.exports.tests.cutoff_frequency = function(test, common) {
-  test('cutoff_frequency variable should be presented in query', function(t) {
-    var store = getBaseVariableStore();
-    store.var('ngram:cutoff_frequency', 'cutoff_frequency value');
-
-    var actual = ngrams(store);
-
-    var expected = {
-      match: {
-        'field value': {
-          analyzer: { $: 'analyzer value' },
-          boost: { $: 'boost value' },
-          query: { $: 'name value' },
-          cutoff_frequency: { $: 'cutoff_frequency value' }
-        }
-      }
-    };
-
-    t.deepEquals(actual, expected, 'should have returned object with cutoff_frequency field');
-    t.end();
-
-  });
-};
-
 module.exports.tests.minimum_should_match = function(test, common) {
   test('minimum_should_match variable should be presented in query', function(t) {
     var store = getBaseVariableStore();

--- a/test/view/phrase.js
+++ b/test/view/phrase.js
@@ -92,33 +92,6 @@ module.exports.tests.fuzziness_variable = function(test, common) {
   });
 };
 
-module.exports.tests.cutoff_frequency = function(test, common) {
-  test('cutoff_frequency variable should be presented in query', function(t) {
-    var store = getBaseVariableStore();
-    store.var('phrase:cutoff_frequency', 'cutoff_frequency value');
-
-    var actual = phrase(store);
-
-    var expected = {
-      match: {
-        'field value': {
-          analyzer: { $: 'analyzer value' },
-          type: 'phrase',
-          boost: { $: 'boost value' },
-          slop: { $: 'slop value' },
-          query: { $: 'name value' },
-          cutoff_frequency: { $: 'cutoff_frequency value' }
-        }
-      }
-    };
-
-    t.deepEquals(actual, expected, 'should have returned object with cutoff_frequency field');
-    t.end();
-
-  });
-};
-
-
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('phrase ' + name, testFunction);

--- a/view/address.js
+++ b/view/address.js
@@ -26,11 +26,6 @@ module.exports = function( property ){
       query: vs.var('input:'+property)
     };
 
-    // optional 'cutoff_frequency' property
-    if( vs.isset('address:'+property+':cutoff_frequency') ){
-      section.cutoff_frequency = vs.var('address:'+property+':cutoff_frequency');
-    }
-
     return view;
   };
 };

--- a/view/admin.js
+++ b/view/admin.js
@@ -26,11 +26,6 @@ module.exports = function( property ){
       query: vs.var('input:'+property)
     };
 
-    // optional 'cutoff_frequency' property
-    if( vs.isset('admin:'+property+':cutoff_frequency') ){
-      section.cutoff_frequency = vs.var('admin:'+property+':cutoff_frequency');
-    }
-
     return view;
   };
 };

--- a/view/leaf/match.js
+++ b/view/leaf/match.js
@@ -15,7 +15,6 @@ module.exports = function( prefix ){
     const optional_params = ['boost',
       'operator',
       'analyzer',
-      'cutoff_frequency',
       'fuzziness',
       'max_expansions',
       'prefix_length',

--- a/view/ngrams.js
+++ b/view/ngrams.js
@@ -23,10 +23,6 @@ module.exports = function( vs ){
     view.match[ vs.var('ngram:field') ].fuzziness = vs.var('ngram:fuzziness');
   }
 
-  if (vs.isset('ngram:cutoff_frequency')) {
-    view.match[ vs.var('ngram:field') ].cutoff_frequency = vs.var('ngram:cutoff_frequency');
-  }
-
   if (vs.isset('ngram:minimum_should_match')) {
     view.match[ vs.var('ngram:field') ].minimum_should_match = vs.var('ngram:minimum_should_match');
   }

--- a/view/phrase.js
+++ b/view/phrase.js
@@ -26,9 +26,5 @@ module.exports = function( vs ){
     view.match[ vs.var('phrase:field') ].fuzziness = vs.var('phrase:fuzziness');
   }
 
-  if (vs.isset('phrase:cutoff_frequency')) {
-    view.match[ vs.var('phrase:field') ].cutoff_frequency = vs.var('phrase:cutoff_frequency');
-  }
-
   return view;
 };


### PR DESCRIPTION
From https://www.elastic.co/guide/en/elasticsearch/reference/8.8/migrating-8.0.html

    The cutoff_frequency parameter has been removed from the match and
    multi_match query.

    Details
    The cutoff_frequency parameter, deprecated in 7.x, has been removed
    in 8.0 from match and multi_match queries. The same functionality
    can be achieved without any configuration provided that the total
    number of hits is not tracked.

    Impact
    Discontinue use of the cutoff_frequency parameter. Search requests
    containing this parameter in a match or multi_match query will
    return an error.

Note in the above "...provided that the total number of hits is not tracked".

`track_total_hits` does not appear in the pelias codebases, so we shouldn't have any issues there.

---
#### Here's what actually got changed :clap:

I deleted all usage of cutoff_frequency and updated the tests.

---
#### Here's how others can test the changes :eyes:

I believe this is only used by pelias-api, so I've tested it via:
- `cd pelias/api && npm test` (with [my fork](https://github.com/pelias/api/compare/master...michaelkirk-pelias:api:mkirk/remove-cutoff-freq) that uses this branch.)
- `cd pelias/docker/projects/north-america && ../../pelias test run` (with [my fork](https://github.com/michaelkirk-pelias/docker/tree/mkirk/remove-cutoff-freq) that uses this branch.)

I haven't tested it against the planet or other builds.

Note: The north-america tests aren't all passing, but the ones that are failing are exactly the same as when I run from current master. I'm assuming (🤞) that the failures reflect changes in the input data since the tests were updated, as [hypothesized over here](https://github.com/pelias/docker/issues/304).

```
Aggregate test results
Pass: 233
Improvements: 18
Expected Failures: 28
Placeholders: 0
Regressions: 84
Total tests: 363
Took 7774ms
Test success rate 76.86%
```

[north-america integration test output before](https://github.com/pelias/api/files/12135110/test-main-4.out.txt)
[north-america test output after](https://github.com/pelias/api/files/12135111/test-remove-cutoff-freq.out.txt)

closes https://github.com/pelias/query/issues/118