### PR TITLE
improve structured geocoding postcode matching

### DIFF
--- a/layout/StructuredFallbackQuery.js
+++ b/layout/StructuredFallbackQuery.js
@@ -503,7 +503,8 @@ function addPostCode(vs) {
     vs.var('input:postcode').toString(),
     'postalcode',
     [
-      'parent.postalcode'
+      'parent.postalcode',
+      'address_parts.zip'
     ],
     false
   );

--- a/test/fixtures/structuredFallbackQuery/address_with_postcode.json
+++ b/test/fixtures/structuredFallbackQuery/address_with_postcode.json
@@ -78,7 +78,10 @@
                     "multi_match": {
                       "query": "postcode value",
                       "type": "phrase",
-                      "fields": ["parent.postalcode"]
+                      "fields": [
+                        "parent.postalcode",
+                        "address_parts.zip"
+                      ]
                     }
                   }
                 ],

--- a/test/fixtures/structuredFallbackQuery/postcode.json
+++ b/test/fixtures/structuredFallbackQuery/postcode.json
@@ -1,0 +1,43 @@
+{
+  "query": {
+    "function_score": {
+      "query": {
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.postalcode",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "postcode value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.postalcode"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "postalcode"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "max_boost": 20,
+      "functions": [],
+      "score_mode": "avg",
+      "boost_mode": "multiply"
+    }
+  },
+  "sort": [
+    "_score"
+  ],
+  "size": "size value",
+  "track_scores": "track_scores value"
+}

--- a/test/fixtures/structuredFallbackQuery/postcode.json
+++ b/test/fixtures/structuredFallbackQuery/postcode.json
@@ -14,7 +14,8 @@
                       "query": "postcode value",
                       "type": "phrase",
                       "fields": [
-                        "parent.postalcode"
+                        "parent.postalcode",
+                        "address_parts.zip"
                       ]
                     }
                   }

--- a/test/layout/StructuredFallbackQuery.js
+++ b/test/layout/StructuredFallbackQuery.js
@@ -36,6 +36,22 @@ module.exports.tests.base_render = function(test, common) {
 
   });
 
+  test('VariableStore with postcode only', function(t) {
+    var query = new StructuredFallbackQuery();
+
+    var vs = new VariableStore();
+    vs.var('size', 'size value');
+    vs.var('track_scores', 'track_scores value');
+    vs.var('input:postcode', 'postcode value');
+
+    var actual = JSON.parse(JSON.stringify(query.render(vs)));
+    var expected = require('../fixtures/structuredFallbackQuery/postcode.json');
+
+    t.deepEquals(actual, expected);
+    t.end();
+
+  });
+
   test('VariableStore with address and less granular fields should include all others', function(t) {
     var query = new StructuredFallbackQuery();
 


### PR DESCRIPTION
as discussed in https://github.com/pelias/api/issues/1548 only the `parent.postalcode` field is being used for matching, adding the `address_parts.zip` field greatly improves matching as it is what is being used for `osm`/ `oa`/ `custom` layers.

I've included a new test fixture in this PR which covers the case where *only* the postcode field is specified for a structured query.

closes https://github.com/pelias/api/issues/1548