### PR TITLE
 improve unit number sorting for `fallback.housenumber` queries (v1/search)

### DIFF
--- a/layout/StructuredFallbackQuery.js
+++ b/layout/StructuredFallbackQuery.js
@@ -264,7 +264,11 @@ function addHouseNumberAndStreet(vs) {
         match_phrase('address_parts.number', vs.var('input:housenumber')),
         match_phrase('address_parts.street', vs.var('input:street'), { slop: vs.var('address:street:slop') })
       ],
-      should: [],
+      should: [
+        // non-numeric tokens are stripped from the index, use the phrase field to improve sorting.
+        // see: https://github.com/pelias/pelias/issues/810
+        match_phrase('phrase.default', vs.var('input:housenumber'))
+      ],
       filter: {
         term: {
           layer: 'address'

--- a/test/fixtures/structuredFallbackQuery/address_with_postcode.json
+++ b/test/fixtures/structuredFallbackQuery/address_with_postcode.json
@@ -28,6 +28,13 @@
                 "should": [
                   {
                     "match_phrase": {
+                      "phrase.default": {
+                        "query": "house number value"
+                      }
+                    }
+                  },
+                  {
+                    "match_phrase": {
                       "address_parts.zip": {
                         "query": "postcode value"
                       }

--- a/test/fixtures/structuredFallbackQuery/query.json
+++ b/test/fixtures/structuredFallbackQuery/query.json
@@ -183,7 +183,15 @@
                     }
                   }
                 ],
-                "should": [],
+                "should": [
+                  {
+                    "match_phrase": {
+                      "phrase.default": {
+                        "query": "house number value"
+                      }
+                    }
+                  }
+                ],
                 "filter": {
                   "term": {
                     "layer": "address"


### PR DESCRIPTION
experiment: https://github.com/pelias/pelias/issues/810
ref: https://github.com/pelias/query/commit/ea5f89c002b82282a6b865e28d7715947759bda1
