### PR TITLE
ES8: Remove bounding box query type parameter

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -11,8 +11,6 @@
   "boundary:circle:radius": "50km",
   "boundary:circle:distance_type": "plane",
 
-  "boundary:rect:type": "indexed",
-
   "ngram:analyzer": "peliasOneEdgeGram",
   "ngram:field": "name.default",
   "ngram:boost": 1,

--- a/test/view/boundary_rect.js
+++ b/test/view/boundary_rect.js
@@ -7,7 +7,6 @@ function getBaseVariableStore(toExclude) {
   vs.var('boundary:rect:right', 'right value');
   vs.var('boundary:rect:bottom', 'bottom value');
   vs.var('boundary:rect:left', 'left value');
-  vs.var('boundary:rect:type', 'type value');
   vs.var('centroid:field', 'field value');
 
   if (toExclude) {
@@ -52,7 +51,6 @@ module.exports.tests.no_exceptions_conditions = function(test, common) {
 
     var expected = {
       geo_bounding_box: {
-        type: { $: 'type value' },
         'field value': {
           top: { $: 'top value' },
           right: { $: 'right value' },

--- a/view/boundary_rect.js
+++ b/view/boundary_rect.js
@@ -6,24 +6,20 @@ module.exports = function( vs ){
       !vs.isset('boundary:rect:right') ||
       !vs.isset('boundary:rect:bottom') ||
       !vs.isset('boundary:rect:left') ||
-      !vs.isset('boundary:rect:type') ||
       !vs.isset('centroid:field') ){
     return null;
   }
 
-  // base view
+  // base view with bbox
   var view = {
     geo_bounding_box: {
-      type: vs.var('boundary:rect:type')
+      [ vs.var('centroid:field') ]: {
+        top: vs.var('boundary:rect:top'),
+        right: vs.var('boundary:rect:right'),
+        bottom: vs.var('boundary:rect:bottom'),
+        left: vs.var('boundary:rect:left')
+      }
     }
-  };
-
-  // bbox
-  view.geo_bounding_box[ vs.var('centroid:field') ] = {
-    top: vs.var('boundary:rect:top'),
-    right: vs.var('boundary:rect:right'),
-    bottom: vs.var('boundary:rect:bottom'),
-    left: vs.var('boundary:rect:left')
   };
 
   return view;


### PR DESCRIPTION
The parameter has been deprecates in 7.14 as it is a no-op.

see elastic/elasticsearch#74536
